### PR TITLE
now storing raw counts in "counts" layer instead of raw

### DIFF
--- a/src/segtraq/rs/region_similarity.py
+++ b/src/segtraq/rs/region_similarity.py
@@ -236,14 +236,14 @@ def similarity_nucleus_cell(
     # Check if X looks like counts
     if _looks_like_counts(X):
         arr = X.toarray() if hasattr(X, "toarray") else X
-    elif "raw" not in tbl.layers:
+    elif "counts" not in tbl.layers:
         raise ValueError(
-            f"'raw' layer does not exist in sdata.tables['{tables_key}'], "
+            f"'counts' layer does not exist in sdata.tables['{tables_key}'], "
             "and the main matrix does not look like counts."
         )
     else:
-        raw = tbl.layers["raw"]
-        arr = raw.toarray() if hasattr(raw, "toarray") else raw
+        counts = tbl.layers["counts"]
+        arr = counts.toarray() if hasattr(counts, "toarray") else counts
 
     expr_cells = pd.DataFrame(
         arr,

--- a/src/segtraq/rs/utils.py
+++ b/src/segtraq/rs/utils.py
@@ -460,14 +460,14 @@ def _compute_ncvs_within_radius(
 
     if _looks_like_counts(X):
         arr = X.toarray() if hasattr(X, "toarray") else X
-    elif "raw" not in ad.layers:
+    elif "counts" not in ad.layers:
         raise ValueError(
-            f"'raw' layer does not exist in sdata.tables['{tables_key}'], "
+            f"'counts' layer does not exist in sdata.tables['{tables_key}'], "
             "and the main matrix does not look like counts."
         )
     else:
-        raw = ad.layers["raw"]
-        arr = raw.toarray() if hasattr(raw, "toarray") else raw
+        counts = ad.layers["counts"]
+        arr = counts.toarray() if hasattr(counts, "toarray") else counts
 
     mask = ad.obs[tables_cell_id_key].isin(cells_gdf.index)
     expr_cells = pd.DataFrame(

--- a/src/segtraq/sp/supervised.py
+++ b/src/segtraq/sp/supervised.py
@@ -212,14 +212,14 @@ def calculate_neighbor_contamination(
     # Dense expression (counts)
     if _looks_like_counts(X):
         X_dense = X.toarray() if hasattr(X, "toarray") else X
-    elif "raw" not in adata.layers:
+    elif "counts" not in adata.layers:
         raise ValueError(
-            f"'raw' layer does not exist in sdata.tables['{tables_key}'], "
+            f"'counts' layer does not exist in sdata.tables['{tables_key}'], "
             "and the main matrix does not look like counts."
         )
     else:
-        raw = adata.layers["raw"]
-        X_dense = raw.toarray() if hasattr(raw, "toarray") else raw
+        counts = adata.layers["counts"]
+        X_dense = counts.toarray() if hasattr(counts, "toarray") else counts
 
     # Neighbors
     if neighbors_key not in adata.obsp:
@@ -507,14 +507,14 @@ def calculate_marker_purity(
 
     if _looks_like_counts(X):
         X_dense = X.toarray() if hasattr(X, "toarray") else X
-    elif "raw" not in adata.layers:
+    elif "counts" not in adata.layers:
         raise ValueError(
-            f"'raw' layer does not exist in sdata.tables['{tables_key}'], "
+            f"'counts' layer does not exist in sdata.tables['{tables_key}'], "
             "and the main matrix does not look like counts."
         )
     else:
-        raw = adata.layers["raw"]
-        X_dense = raw.toarray() if hasattr(raw, "toarray") else raw
+        counts = adata.layers["counts"]
+        X_dense = counts.toarray() if hasattr(counts, "toarray") else counts
 
     genes = np.asarray(adata.var_names)
     var_index = pd.Index(genes)
@@ -758,11 +758,11 @@ def neighbor_prediction(
         warnings.warn(
             "Reference adata does not appear log-normalized."
             "Counts will be log1p-transformed before running label transfer."
-            "Raw counts will be stored in `adata.layers['raw']`.",
+            "Raw counts will be stored in `adata.layers['counts']`.",
             RuntimeWarning,
             stacklevel=2,
         )
-        adata.layers["raw"] = adata.X.copy()
+        adata.layers["counts"] = adata.X.copy()
         sc.pp.normalize_total(adata, target_sum=1e4)
         sc.pp.log1p(adata)
 

--- a/src/segtraq/utils.py
+++ b/src/segtraq/utils.py
@@ -367,11 +367,11 @@ def run_label_transfer(
         warnings.warn(
             "Reference adata_ref does not appear log-normalized."
             "Counts will be log1p-transformed before running label transfer."
-            "Raw counts will be stored in `adata_ref.raw`.",
+            "Raw counts will be stored in `adata_ref.layers['counts']`.",
             RuntimeWarning,
             stacklevel=2,
         )
-        adata_ref.raw = adata_ref.X.copy()
+        adata_ref.layers["counts"] = adata_ref.X.copy()
         sc.pp.normalize_total(adata_ref, target_sum=1e4)
         sc.pp.log1p(adata_ref)
 
@@ -419,11 +419,11 @@ def run_label_transfer(
         warnings.warn(
             "Spatialdata table appears to contain raw counts. "
             "Counts will be log1p-transformed before running label transfer."
-            'Raw counts will be stored in `adata_q.layers["raw"]`.',
+            'Raw counts will be stored in `adata_q.layers["counts"]`.',
             RuntimeWarning,
             stacklevel=2,
         )
-        adata_q.layers["raw"] = adata_q.X
+        adata_q.layers["counts"] = adata_q.X
         sc.pp.normalize_total(adata_q)
         sc.pp.log1p(adata_q)
 
@@ -704,10 +704,12 @@ def get_ref_markers(
     if _looks_like_counts(adata.X):
         warnings.warn(
             "Reference adata_ref does not appear log-normalized. "
-            "normalize_total + log1p will be applied to a copy for marker computation.",
+            "normalize_total + log1p will be applied to a copy for marker computation."
+            "Raw counts will be stored in `adata_ref.layers['counts']`.",
             RuntimeWarning,
             stacklevel=2,
         )
+        adata.layers["counts"] = adata.X.copy()
         sc.pp.normalize_total(adata, target_sum=1e4)
         sc.pp.log1p(adata)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ def test_sdata_new():
 
     # adding raw counts etc.
     adata = sdata_new.tables["table"]
-    adata.layers["raw"] = adata.X.copy()
+    adata.layers["counts"] = adata.X.copy()
     # normalizing and log-transforming the counts
     sc.pp.normalize_total(adata, inplace=True)
     sc.pp.log1p(adata)


### PR DESCRIPTION
The reason is that using "raw" can either refer to `adata.layers['raw']` (where cells and genes are synced) or `adata.raw` (which is a snapshot where no filtering is performed when you select e.g. HVGs). For consistency, counts are now always stored in `adata.layers["counts"]`.

Addresses #102. Still need to adapt all notebooks accordingly.