### PR TITLE
Csama/fix

### DIFF
--- a/src/segtraq/SegTraQ.py
+++ b/src/segtraq/SegTraQ.py
@@ -259,6 +259,7 @@ class SegTraQ:
     def run_region_similarity(
         self,
         n_jobs: int = -1,
+        parallel_backend: str = "threading",
         inplace: bool = True,
         iou_kwargs: dict = None,
         similarity_nucleus_cell_kwargs: dict = None,
@@ -286,18 +287,21 @@ class SegTraQ:
         """
         ious = self.rs.match_nuclei_to_cells(
             n_jobs=n_jobs,
+            parallel_backend=parallel_backend,
             inplace=inplace,
             **(iou_kwargs or {}),
         )
 
         similarity_nucleus_cell = self.rs.similarity_nucleus_cell(
             n_jobs=n_jobs,
+            parallel_backend=parallel_backend,
             inplace=inplace,
             **(similarity_nucleus_cell_kwargs or {}),
         )
 
         similarity_nucleus_cytoplasm = self.rs.similarity_nucleus_cytoplasm(
             n_jobs=n_jobs,
+            parallel_backend=parallel_backend,
             inplace=inplace,
             **(similarity_nucleus_cytoplasm_kwargs or {}),
         )
@@ -314,6 +318,7 @@ class SegTraQ:
 
         border_admixture_score = self.rs.border_admixture_score(
             n_jobs=n_jobs,
+            parallel_backend=parallel_backend,
             inplace=inplace,
             **(border_admixture_score_kwargs or {}),
         )
@@ -1017,7 +1022,13 @@ class _BLFacade:
 
     transcripts_per_cell.__doc__ = bl.transcripts_per_cell.__doc__
 
-    def morphological_features(self, features_to_compute: list | None = None, n_jobs: int = -1, inplace: bool = True):
+    def morphological_features(
+        self,
+        features_to_compute: list | None = None,
+        n_jobs: int = -1,
+        parallel_backend: str = "threading",
+        inplace: bool = True,
+    ):
         return bl.morphological_features(
             sdata=self._p.sdata,
             tables_cell_id_key=self._p.tables_cell_id_key,
@@ -1026,6 +1037,7 @@ class _BLFacade:
             shapes_key=self._p.shapes_key,
             features_to_compute=features_to_compute,
             n_jobs=n_jobs,
+            parallel_backend=parallel_backend,
             tables_key=self._p.tables_key,
             inplace=inplace,
         )
@@ -1062,6 +1074,7 @@ class _RSFacade:
         select_by: str = "nucleus_fraction",
         min_intersection_area: float = 0.0,
         n_jobs: int = -1,
+        parallel_backend: str = "threading",
         inplace: bool = True,
     ):
         return rs.match_nuclei_to_cells(
@@ -1073,6 +1086,7 @@ class _RSFacade:
             select_by=select_by,
             min_intersection_area=min_intersection_area,
             n_jobs=n_jobs,
+            parallel_backend=parallel_backend,
             inplace=inplace,
         )
 
@@ -1085,6 +1099,7 @@ class _RSFacade:
         select_by: str = "nucleus_fraction",
         min_intersection_area: float = 0.0,
         n_jobs: int = -1,
+        parallel_backend: str = "threading",
         scale: float = 1e4,
         inplace: bool = True,
     ):
@@ -1105,6 +1120,7 @@ class _RSFacade:
             select_by=select_by,
             min_intersection_area=min_intersection_area,
             n_jobs=n_jobs,
+            parallel_backend=parallel_backend,
             scale=scale,
             inplace=inplace,
         )
@@ -1119,6 +1135,7 @@ class _RSFacade:
         select_by: str = "nucleus_fraction",
         min_intersection_area: float = 0.0,
         n_jobs: int = -1,
+        parallel_backend: str = "threading",
         inplace: bool = True,
     ):
         return rs.similarity_nucleus_cytoplasm(
@@ -1139,6 +1156,7 @@ class _RSFacade:
             select_by=select_by,
             min_intersection_area=min_intersection_area,
             n_jobs=n_jobs,
+            parallel_backend=parallel_backend,
             inplace=inplace,
         )
 
@@ -1218,6 +1236,7 @@ class _RSFacade:
         ci_level: float = 0.95,
         random_state: int | None = None,
         n_jobs: int = -1,
+        parallel_backend: str = "threading",
         inplace: bool = True,
     ):
         return rs.border_admixture_score(
@@ -1241,6 +1260,7 @@ class _RSFacade:
             ci_level=ci_level,
             random_state=random_state,
             n_jobs=n_jobs,
+            parallel_backend=parallel_backend,
             inplace=inplace,
         )
 
@@ -1348,6 +1368,7 @@ class _PSFacade:
         select_by: Literal["iou", "nucleus_fraction"] = "nucleus_fraction",
         min_intersection_area: float = 0.0,
         n_jobs: int = -1,
+        parallel_backend: str = "threading",
         predicate: str = "intersects",
         inplace: bool = True,
     ):
@@ -1369,6 +1390,7 @@ class _PSFacade:
             select_by=select_by,
             min_intersection_area=min_intersection_area,
             n_jobs=n_jobs,
+            parallel_backend=parallel_backend,
             predicate=predicate,
             inplace=inplace,
         )
@@ -1385,6 +1407,7 @@ class _PSFacade:
         select_by: Literal["iou", "nucleus_fraction"] = "nucleus_fraction",
         min_intersection_area: float = 0.0,
         n_jobs: int = -1,
+        parallel_backend: str = "threading",
         inplace: bool = True,
     ):
         return ps.distance_to_centroid(
@@ -1408,6 +1431,7 @@ class _PSFacade:
             select_by=select_by,
             min_intersection_area=min_intersection_area,
             n_jobs=n_jobs,
+            parallel_backend=parallel_backend,
             inplace=inplace,
         )
 
@@ -1423,6 +1447,7 @@ class _PSFacade:
         select_by: Literal["iou", "nucleus_fraction"] = "nucleus_fraction",
         min_intersection_area: float = 0.0,
         n_jobs: int = -1,
+        parallel_backend: str = "threading",
         signed: bool = True,
         inverse_score: bool = True,
         eps: float = 1e-6,
@@ -1449,6 +1474,7 @@ class _PSFacade:
             select_by=select_by,
             min_intersection_area=min_intersection_area,
             n_jobs=n_jobs,
+            parallel_backend=parallel_backend,
             signed=signed,
             inverse_score=inverse_score,
             eps=eps,

--- a/src/segtraq/bl/baseline.py
+++ b/src/segtraq/bl/baseline.py
@@ -465,6 +465,7 @@ def morphological_features(
     shapes_key: str = "cell_boundaries",
     features_to_compute: list | None = None,
     n_jobs: int = -1,  # number of parallel jobs, -1 uses all CPUs
+    parallel_backend: str = "threading",
     tables_key: str = "table",
     inplace: bool = True,
 ):
@@ -490,6 +491,8 @@ def morphological_features(
     n_jobs : int, optional
         Number of parallel jobs to use for computation.
         Default `-1` uses all available CPU cores.
+    parallel_backend : str, optional
+        Parallelization backend to use with joblib. Default is "threading".
     tables_key : str, optional
         The key to access the AnnData table from `sdata.tables`. Default is "table".
     inplace : bool, optional
@@ -543,9 +546,6 @@ def morphological_features(
     cells = sdata.shapes[shapes_key]
     if not isinstance(cells, gpd.GeoDataFrame):
         cells = cells.to_gdf()
-
-    # Filter valid geometries
-    cells = cells[cells.geometry.notnull() & cells.geometry.is_valid].copy()
 
     features = pd.DataFrame()
 
@@ -654,7 +654,7 @@ def morphological_features(
         return elongation, eccentricity
 
     if "elongation" in features_to_compute or "eccentricity" in features_to_compute:
-        results = Parallel(n_jobs=n_jobs)(delayed(compute_elong_ecc)(poly) for poly in geom)
+        results = Parallel(n_jobs=n_jobs, backend=parallel_backend)(delayed(compute_elong_ecc)(poly) for poly in geom)
         elongations, eccentricities = zip(*results, strict=False)
         if "elongation" in features_to_compute:
             features["elongation"] = elongations

--- a/src/segtraq/ps/point_statistics.py
+++ b/src/segtraq/ps/point_statistics.py
@@ -29,6 +29,7 @@ def percentage_transcripts_in_compartments(
     select_by: Literal["iou", "nucleus_fraction"] = "nucleus_fraction",
     min_intersection_area: float = 0.0,
     n_jobs: int = -1,
+    parallel_backend: str = "threading",
     predicate: str = "intersects",
     inplace: bool = True,
 ) -> pd.DataFrame:
@@ -84,6 +85,8 @@ def percentage_transcripts_in_compartments(
     n_jobs : int, default=-1
         Number of parallel jobs for cell-nucleus matching (if needed).
         Default `-1` uses all available CPU cores.
+    parallel_backend : str, optional
+        Parallelization backend to use with joblib. Default is "threading".
     predicate : str, default="intersects"
         Geometric predicate used to assign transcripts to cell or nucleus polygons during
         spatial joins (e.g. "covers" includes boundary points, "intersects" is more permissive).
@@ -145,6 +148,7 @@ def percentage_transcripts_in_compartments(
             select_by=select_by,
             min_intersection_area=min_intersection_area,
             n_jobs=n_jobs,
+            parallel_backend=parallel_backend,
             inplace=True,
         )
 
@@ -284,6 +288,7 @@ def distance_to_centroid(
     select_by: Literal["iou", "nucleus_fraction"] = "nucleus_fraction",
     min_intersection_area: float = 0.0,
     n_jobs: int = -1,
+    parallel_backend: str = "threading",
     inplace: bool = True,
 ) -> pd.DataFrame:
     """
@@ -340,6 +345,8 @@ def distance_to_centroid(
     n_jobs : int, default=-1
         Number of parallel jobs for cell-nucleus matching (if needed).
         Default `-1` uses all available CPU cores.
+    parallel_backend : str, optional
+        Parallelization backend to use with joblib. Default is "threading".
     inplace : bool, default=True
         Whether to add the results to `sdata.tables`. Default is True.
 
@@ -396,6 +403,7 @@ def distance_to_centroid(
         select_by=select_by,
         min_intersection_area=min_intersection_area,
         n_jobs=n_jobs,
+        parallel_backend=parallel_backend,
         inplace=inplace,
     )
 
@@ -494,6 +502,7 @@ def distance_to_membrane(
     select_by: Literal["iou", "nucleus_fraction"] = "nucleus_fraction",
     min_intersection_area: float = 0.0,
     n_jobs: int = -1,
+    parallel_backend: str = "threading",
     signed: bool = True,
     inverse_score: bool = True,
     eps: float = 1e-6,
@@ -558,6 +567,8 @@ def distance_to_membrane(
     n_jobs : int, default=1
         Number of parallel jobs for cell-nucleus matching (if needed).
         Default `-1` uses all available CPU cores.
+    parallel_backend : str, optional
+        Parallelization backend to use with joblib. Default is "threading".
     signed : bool, default=True
         If True, returns signed distances (positive if transcript is inside/on the polygon,
         negative if outside). If False, returns unsigned distances to the boundary.
@@ -625,6 +636,7 @@ def distance_to_membrane(
         select_by=select_by,
         min_intersection_area=min_intersection_area,
         n_jobs=n_jobs,
+        parallel_backend=parallel_backend,
         inplace=inplace,
     )
 

--- a/src/segtraq/ps/utils.py
+++ b/src/segtraq/ps/utils.py
@@ -20,6 +20,7 @@ def _get_cell_geometry_lookup(
     select_by: Literal["iou", "nucleus_fraction"],
     min_intersection_area: float,
     n_jobs: int,
+    parallel_backend: str,
     inplace: bool,
 ) -> tuple[pd.DataFrame, gpd.GeoDataFrame]:
     """
@@ -55,6 +56,7 @@ def _get_cell_geometry_lookup(
             select_by=select_by,
             min_intersection_area=min_intersection_area,
             n_jobs=n_jobs,
+            parallel_backend=parallel_backend,
             inplace=inplace,
         )
 

--- a/src/segtraq/rs/region_similarity.py
+++ b/src/segtraq/rs/region_similarity.py
@@ -24,6 +24,7 @@ def match_nuclei_to_cells(
     select_by: str = "nucleus_fraction",
     min_intersection_area: float = 0.0,
     n_jobs: int = -1,
+    parallel_backend: str = "threading",
     inplace: bool = True,
 ) -> DataFrame:
     """
@@ -56,6 +57,8 @@ def match_nuclei_to_cells(
         Overlaps <= this threshold are ignored.
     n_jobs : int, optional
         Number of parallel jobs. Default `-1` uses all available CPU cores.
+    parallel_backend : str, optional
+        Parallelization backend to use with joblib. Default is "threading".
     inplace : bool, optional
         Whether to add the results to `sdata.tables`. Default is True.
 
@@ -83,7 +86,7 @@ def match_nuclei_to_cells(
     nuc_sindex = nuc_boundaries.sindex
 
     # Parallel loop over cells
-    results = Parallel(n_jobs=n_jobs, verbose=0, prefer="threads")(
+    results = Parallel(n_jobs=n_jobs, verbose=0, backend=parallel_backend)(
         delayed(_match_nucleus_one_cell)(
             cell_row=cell_row,
             nucleus_shapes=nuc_boundaries,
@@ -134,6 +137,7 @@ def similarity_nucleus_cell(
     select_by: str = "nucleus_fraction",
     min_intersection_area: float = 0.0,
     n_jobs: int = -1,
+    parallel_backend: str = "threading",
     scale: float = 1e4,
     inplace: bool = True,
 ) -> pd.DataFrame:
@@ -185,6 +189,8 @@ def similarity_nucleus_cell(
     n_jobs : int, default=-1
         Number of jobs for computing cell-nucleus matches if they have not yet
         been calculated. Default `-1` uses all available CPU cores.
+    parallel_backend : str, optional
+        Parallelization backend to use with joblib. Default is "threading".
     scale : float, default=1e4
         Library-size normalization scale used before log1p.
     inplace : bool, default=True
@@ -226,6 +232,7 @@ def similarity_nucleus_cell(
             min_intersection_area=min_intersection_area,
             select_by=select_by,
             n_jobs=n_jobs,
+            parallel_backend=parallel_backend,
             inplace=inplace,
         )
     else:
@@ -331,6 +338,7 @@ def similarity_nucleus_cytoplasm(
     select_by: str = "nucleus_fraction",
     min_intersection_area: float = 0.0,
     n_jobs: int = -1,
+    parallel_backend: str = "threading",
     inplace: bool = True,
 ) -> pd.DataFrame:
     """
@@ -386,6 +394,8 @@ def similarity_nucleus_cytoplasm(
     n_jobs : int, default=-1
         Number of jobs for computing cell-nucleus matches if they have not yet
         been calculated. Default `-1` uses all available CPU cores.
+        parallel_backend : str, optional
+        Parallelization backend to use with joblib. Default is "threading".
     inplace : bool, default=True
         Whether to merge the results into `sdata.tables[tables_key].obs`.
 
@@ -424,6 +434,7 @@ def similarity_nucleus_cytoplasm(
             min_intersection_area=min_intersection_area,
             select_by=select_by,
             n_jobs=n_jobs,
+            parallel_backend=parallel_backend,
             inplace=inplace,
         )
     else:
@@ -836,6 +847,7 @@ def border_admixture_score(
     ci_level: float = 0.95,
     random_state: int | None = None,
     n_jobs: int = -1,
+    parallel_backend: str = "threading",
     inplace: bool = True,
 ) -> pd.DataFrame:
     """
@@ -902,6 +914,8 @@ def border_admixture_score(
         Random seed for reproducible bootstrap resampling.
     n_jobs : int, default=-1
         Number of parallel jobs across cells. Default `-1` uses all available CPU cores.
+    parallel_backend : str, optional
+        Parallelization backend to use with joblib. Default is "threading".
     inplace : bool, default=True
         If True, merge the results into `sdata.tables[tables_key].obs`.
 
@@ -982,7 +996,7 @@ def border_admixture_score(
             "border_admixture_score_ci_high": res["border_admixture_score_ci_high"],
         }
 
-    rows = Parallel(n_jobs=n_jobs)(
+    rows = Parallel(n_jobs=n_jobs, backend=parallel_backend)(
         delayed(_bootstrap_mixture_fit_one_cell)(cid, seed) for cid, seed in zip(common_cells, seeds, strict=False)
     )
 

--- a/src/segtraq/sp/supervised.py
+++ b/src/segtraq/sp/supervised.py
@@ -89,6 +89,9 @@ def mutually_exclusive_coexpression_rate(
     rows = []
     # go over all positive/negative gene pairs from the scRNAseq reference that were kept through the filtering
     for g1, g2 in kept_pairs:
+        # avoid requiring markers to be pre-filtered to genes present in the spatial data
+        if g1 not in var_index or g2 not in var_index:
+            continue
         i1, i2 = var_index.get_loc(g1), var_index.get_loc(g2)
         # extract all cell types positive/negative for combination from the spatial data for the
         # mutually exclusive gene pairs found in the scRNA seq data.


### PR DESCRIPTION
## Bug fixes - found while preparing the CSAMA tutorial

- **NaN centroids:** Some cells end up with `NaN` centroids during `validate_spatialdata()`, where centroids are computed if missing from `adata.obs`. This affects neighbor-based modules (`rs`, `sp`). 

  - solution: excluded this line `cells = cells[cells.geometry.notnull() & cells.geometry.is_valid].copy()` in `morphological_features` to avoid `NaN` centroids

- **SpatialData index lost:** `spatialdata_io.xenium()` removes the shape index name after setting `cell_id` as index. This breaks `validate_spatialdata()`. Should likely be reported upstream to `SpatialData`. Tutorials should currently include: `sdata.shapes["cell_boundaries"].index.name = "cell_id"`

  - solution: this was reported to `SpatialData` in this [issue](https://github.com/scverse/spatialdata/issues/1126#issuecomment-4429697911) and is being fixed

- **Joblib backend:**`joblib.parallel.DEFAULT_BACKEND = "threading"` currently needs to be set manually for `bl.morphological_features()` to work. Consider setting this internally in the module.

  - solution:`parallel_threading` is now a parameter and defaults to `threading`

- **Common genes between ref &query:** query and reference datasets currently need to be manually subset to common genes before running the supervised module. This should be handled internally.

  - solution: `mutually_exclusive_coexpression_rate` now filters to genes present in markers, so manual prefiltering to common is not necessary

