### PR TITLE
fixed bug in ps module due to the new merge_into_obs logic

### DIFF
--- a/src/segtraq/ps/point_statistics.py
+++ b/src/segtraq/ps/point_statistics.py
@@ -243,6 +243,8 @@ def percentage_transcripts_in_compartments(
         ]
     ]
 
+    # writing the cell ID (currently index) into its own column
+    out[points_cell_id_key] = out.index.values
     out = out.rename(
         columns={
             "num_total": f"num_total_{feature}",


### PR DESCRIPTION
With the new `merge_into_obs()` logic, the cell ID is required to be a column, which wasn't the case in `ps.percentage_transcripts_in_compartments()`.