### PR TITLE
filtering of control and low-quality transcripts now always happens inplace

### DIFF
--- a/src/segtraq/SegTraQ.py
+++ b/src/segtraq/SegTraQ.py
@@ -24,6 +24,7 @@ DEFAULT_FILTER_KWARGS = {
         "UnassignedCodeword_",
     ),
     "control_genes": (),
+    "inplace": True,
 }
 
 
@@ -131,7 +132,7 @@ class SegTraQ:
         filter_kwargs : dict or None, optional
             If `filter_low_quality_transcripts` is True, these keyword arguments are forwarded
             to the filtering function.
-            Possible keys are: `min_qv`, `control_genes`, `control_prefixes`.
+            Possible keys are: `min_qv`, `control_genes`, `control_prefixes`, `inplace`.
             Please refer to the function `_filter_control_and_low_quality_transcripts` for details.
 
         Notes
@@ -167,7 +168,8 @@ class SegTraQ:
         # optionally filter out low-quality and control transcripts that would otherwise skew metrics
         if filter_low_quality_transcripts:
             resolved_kwargs = {**DEFAULT_FILTER_KWARGS, **(filter_kwargs or {})}
-            # note that this is not inplace to avoid modifying the original data
+            # by default, this modifies the input SpatialData object in-place and 
+            # issues a warning about this
             sdata_new = _filter_control_and_low_quality_transcripts(
                 sdata,
                 min_qv=resolved_kwargs["min_qv"],
@@ -180,6 +182,7 @@ class SegTraQ:
                 tables_key=tables_key,
                 tables_cell_id_key=tables_cell_id_key,
                 recompute_expression=True,
+                inplace=resolved_kwargs["inplace"],
             )
         else:
             sdata_new = sdata

--- a/src/segtraq/SegTraQ.py
+++ b/src/segtraq/SegTraQ.py
@@ -180,7 +180,6 @@ class SegTraQ:
                 tables_key=tables_key,
                 tables_cell_id_key=tables_cell_id_key,
                 recompute_expression=True,
-                inplace=False,
             )
         else:
             sdata_new = sdata

--- a/src/segtraq/utils.py
+++ b/src/segtraq/utils.py
@@ -1864,7 +1864,6 @@ def _filter_control_and_low_quality_transcripts(
     tables_key: str = "table",
     tables_cell_id_key: str = "cell_id",
     recompute_expression: bool = True,
-    inplace: bool = True,
 ) -> sd.SpatialData:
     """
     Filter control and low-quality transcripts from the SpatialData object.
@@ -1910,16 +1909,20 @@ def _filter_control_and_low_quality_transcripts(
     recompute_expression : bool, default=True
         Whether to recompute the expression matrix after filtering.
         Note that this can be computationally expensive for large datasets.
-    inplace : bool, default=True
-        Whether to modify the SpatialData object in place. Defaults to True.
 
     Returns
     -------
     sd.SpatialData
         The updated SpatialData object with invalid transcripts marked (in an extra column).
     """
-    if not inplace:
-        sdata = sd.deepcopy(sdata)
+    # there used to be the option of not doing this in-place
+    # however, spatialdata's deepcopy function introduces issues with the points,
+    # hence we now only support in-place filtering
+    warnings.warn(
+        "Filtering control and low-quality transcripts from the SpatialData object in-place.",
+        UserWarning,
+        stacklevel=2,
+    )
 
     pts = sdata.points[points_key]
     adata = sdata.tables[tables_key]

--- a/src/segtraq/utils.py
+++ b/src/segtraq/utils.py
@@ -1864,6 +1864,7 @@ def _filter_control_and_low_quality_transcripts(
     tables_key: str = "table",
     tables_cell_id_key: str = "cell_id",
     recompute_expression: bool = True,
+    inplace: bool = True,
 ) -> sd.SpatialData:
     """
     Filter control and low-quality transcripts from the SpatialData object.
@@ -1909,20 +1910,23 @@ def _filter_control_and_low_quality_transcripts(
     recompute_expression : bool, default=True
         Whether to recompute the expression matrix after filtering.
         Note that this can be computationally expensive for large datasets.
+    inplace: bool, default=True
+        Whether to modify the SpatialData object in place. Defaults to True.
 
     Returns
     -------
     sd.SpatialData
         The updated SpatialData object with invalid transcripts marked (in an extra column).
     """
-    # there used to be the option of not doing this in-place
-    # however, spatialdata's deepcopy function introduces issues with the points,
-    # hence we now only support in-place filtering
-    warnings.warn(
-        "Filtering control and low-quality transcripts from the SpatialData object in-place.",
-        UserWarning,
-        stacklevel=2,
-    )
+    if inplace:
+        warnings.warn(
+            "Filtering control and low-quality transcripts from the SpatialData object in-place. "
+            "Set filter_kwargs={'inplace': False} to avoid modifying the original object.",
+            UserWarning,
+            stacklevel=2,
+        )
+    else:
+        sdata = sd.deepcopy(sdata)
 
     pts = sdata.points[points_key]
     adata = sdata.tables[tables_key]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,7 @@ def test_sdata_3D():
         shapes_cell_id_key="cell",
         tables_centroid_x_key="centroid_x",
         tables_centroid_y_key="centroid_y",
+        filter_kwargs={"inplace": False},
     )
 
     return sdata_3D
@@ -132,4 +133,5 @@ def test_segtraq_obj(sdata_labeled):
         images_key="image",
         shapes_cell_id_key="cell_id_1",
         tables_cell_id_key="cell_id_2",
+        filter_kwargs={"inplace": False},
     )

--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -6,12 +6,24 @@ import segtraq as st
 
 
 def test_constructor(sdata_new):
-    st.SegTraQ(sdata_new, tables_centroid_x_key="x_centroid", tables_centroid_y_key="y_centroid", images_key="image")
+    st.SegTraQ(
+        sdata_new,
+        tables_centroid_x_key="x_centroid",
+        tables_centroid_y_key="y_centroid",
+        images_key="image",
+        filter_kwargs={"inplace": False},
+    )
 
 
 def test_constructor_invalid_coordinate(sdata_new):
     with pytest.raises(AssertionError, match="Tables DataFrame must contain x coordinate column"):
-        st.SegTraQ(sdata_new, images_key="image", tables_centroid_x_key="x", tables_centroid_y_key="y")
+        st.SegTraQ(
+            sdata_new,
+            images_key="image",
+            tables_centroid_x_key="x",
+            tables_centroid_y_key="y",
+            filter_kwargs={"inplace": False},
+        )
 
 
 def test_constructor_missing_table_centroids(sdata_new):
@@ -21,7 +33,13 @@ def test_constructor_missing_table_centroids(sdata_new):
     centroids_old.columns = ["centroid_x", "centroid_y"]
     sdata.tables["table"].obs.drop(columns=["x_centroid", "y_centroid"], inplace=True)
     # construct SegTraQ object, which should compute the centroids automatically
-    st.SegTraQ(sdata, images_key="image", tables_centroid_x_key=None, tables_centroid_y_key=None)
+    st.SegTraQ(
+        sdata,
+        images_key="image",
+        tables_centroid_x_key=None,
+        tables_centroid_y_key=None,
+        filter_kwargs={"inplace": False},
+    )
     # get the new centroid columns
     centroids_new = sdata.tables["table"].obs[["centroid_x", "centroid_y"]]
     # check that the centroids are close to the old ones

--- a/tests/utils/test_filter_control_genes.py
+++ b/tests/utils/test_filter_control_genes.py
@@ -10,7 +10,6 @@ def test_filter_control_genes(sdata_new):
         tables_key="table",
         points_gene_key="feature_name",
         recompute_expression=False,
-        inplace=False,
     )
 
     # check that the control genes have been removed in transcripts
@@ -44,7 +43,6 @@ def test_filter_control_genes_recompute_expression_matrix(sdata_new):
         points_key="transcripts",
         tables_key="table",
         points_gene_key="feature_name",
-        inplace=False,
     )
 
     # check that the control genes have been removed in transcripts
@@ -72,7 +70,6 @@ def test_filter_control_genes_no_filtering(sdata_new):
         tables_key="table",
         points_gene_key="feature_name",
         recompute_expression=True,
-        inplace=False,
     )
 
     # check that no transcripts have been removed
@@ -99,7 +96,6 @@ def test_filter_control_genes_no_transcripts_remain(sdata_new):
         tables_key="table",
         points_gene_key="feature_name",
         recompute_expression=False,
-        inplace=False,
     )
 
     # check that no transcripts remain
@@ -120,7 +116,6 @@ def test_filter_control_genes_no_transcripts_remain_with_recompute(sdata_new):
         points_key="transcripts",
         tables_key="table",
         points_gene_key="feature_name",
-        inplace=False,
     )
 
     # check that no transcripts remain

--- a/tests/utils/test_filter_control_genes.py
+++ b/tests/utils/test_filter_control_genes.py
@@ -10,6 +10,7 @@ def test_filter_control_genes(sdata_new):
         tables_key="table",
         points_gene_key="feature_name",
         recompute_expression=False,
+        inplace=False,
     )
 
     # check that the control genes have been removed in transcripts
@@ -43,6 +44,7 @@ def test_filter_control_genes_recompute_expression_matrix(sdata_new):
         points_key="transcripts",
         tables_key="table",
         points_gene_key="feature_name",
+        inplace=False,
     )
 
     # check that the control genes have been removed in transcripts
@@ -70,6 +72,7 @@ def test_filter_control_genes_no_filtering(sdata_new):
         tables_key="table",
         points_gene_key="feature_name",
         recompute_expression=True,
+        inplace=False,
     )
 
     # check that no transcripts have been removed
@@ -96,6 +99,7 @@ def test_filter_control_genes_no_transcripts_remain(sdata_new):
         tables_key="table",
         points_gene_key="feature_name",
         recompute_expression=False,
+        inplace=False,
     )
 
     # check that no transcripts remain
@@ -116,6 +120,7 @@ def test_filter_control_genes_no_transcripts_remain_with_recompute(sdata_new):
         points_key="transcripts",
         tables_key="table",
         points_gene_key="feature_name",
+        inplace=False,
     )
 
     # check that no transcripts remain


### PR DESCRIPTION
There is an issue with spatialdata's `deepcopy()` function, which leads to duplicate indices in the points (see #158). This means that we cannot make use of this function in `_filter_low_quality_and_control_transcripts()`. I have made this work in-place instead, which isn't the best way to do things, but unless `spatialdata` fixes their method, this is the best we can do.