### PR TITLE
Bugfix/make unique

### DIFF
--- a/src/segtraq/SegTraQ.py
+++ b/src/segtraq/SegTraQ.py
@@ -958,7 +958,7 @@ class SegTraQ:
     ):
         sp_genes = _get_genes(adata=self.sdata.tables[self.tables_key], gene_key=self.tables_gene_key)
 
-        _make_ref_genes_unique(adata=adata, gene_key=ref_gene_key)
+        adata = _make_ref_genes_unique(adata=adata, gene_key=ref_gene_key)
         sc_genes = _get_genes(adata=adata, gene_key=ref_gene_key)
 
         mask = sc_genes.isin(sp_genes)

--- a/src/segtraq/SegTraQ.py
+++ b/src/segtraq/SegTraQ.py
@@ -958,8 +958,9 @@ class SegTraQ:
     ):
         sp_genes = _get_genes(adata=self.sdata.tables[self.tables_key], gene_key=self.tables_gene_key)
 
+        # copies gene identifiers into var_names and makes them unique (if needed) 
         adata = _make_ref_genes_unique(adata, ref_gene_key=ref_gene_key)
-        sc_genes = _get_genes(adata=adata, gene_key=ref_gene_key)
+        sc_genes = adata.var_names
 
         mask = sc_genes.isin(sp_genes)
         if mask.sum() == 0:

--- a/src/segtraq/SegTraQ.py
+++ b/src/segtraq/SegTraQ.py
@@ -773,99 +773,99 @@ class SegTraQ:
             `"marker_purity"`, `"neighbor_contamination"`, and
             `"mutually_exclusive_coexpression_rate"`.
         """
-    label_transfer_kwargs = (
-        {} if label_transfer_kwargs is None else dict(label_transfer_kwargs)
-    )
-    markers_from_reference_kwargs = (
-        {} if markers_from_reference_kwargs is None
-        else dict(markers_from_reference_kwargs)
-    )
-    purity_kwargs = {} if purity_kwargs is None else dict(purity_kwargs)
-    contamination_kwargs = (
-        {} if contamination_kwargs is None else dict(contamination_kwargs)
-    )
-    mecr_kwargs = {} if mecr_kwargs is None else dict(mecr_kwargs)
+        label_transfer_kwargs = (
+            {} if label_transfer_kwargs is None else dict(label_transfer_kwargs)
+        )
+        markers_from_reference_kwargs = (
+            {} if markers_from_reference_kwargs is None
+            else dict(markers_from_reference_kwargs)
+        )
+        purity_kwargs = {} if purity_kwargs is None else dict(purity_kwargs)
+        contamination_kwargs = (
+            {} if contamination_kwargs is None else dict(contamination_kwargs)
+        )
+        mecr_kwargs = {} if mecr_kwargs is None else dict(mecr_kwargs)
 
-    label_transfer_result = None
+        label_transfer_result = None
 
-    needs_reference = cell_type_key is None or markers is None
+        needs_reference = cell_type_key is None or markers is None
 
-    if needs_reference:
-        if adata_ref is None:
-            raise ValueError(
-                "`adata_ref` is required when "
-                "`cell_type_key=None` or `markers=None`."
+        if needs_reference:
+            if adata_ref is None:
+                raise ValueError(
+                    "`adata_ref` is required when "
+                    "`cell_type_key=None` or `markers=None`."
+                )
+
+            if ref_cell_type is None:
+                raise ValueError(
+                    "`ref_cell_type` is required when "
+                    "`cell_type_key=None` or `markers=None`."
+                )
+
+        if cell_type_key is None:
+            cell_type_key = "transferred_cell_type"
+
+            label_transfer_kwargs["cell_type_key"] = cell_type_key
+            label_transfer_kwargs["inplace"] = True
+
+            label_transfer_result = self.run_label_transfer(
+                adata_ref=adata_ref,
+                ref_cell_type=ref_cell_type,
+                ref_gene_key=ref_gene_key,
+                ref_raw_counts_layer=ref_raw_counts_layer,
+                **label_transfer_kwargs,
             )
 
-        if ref_cell_type is None:
-            raise ValueError(
-                "`ref_cell_type` is required when "
-                "`cell_type_key=None` or `markers=None`."
+        if markers is None:
+            markers = self.markers_from_reference(
+                adata=adata_ref,
+                ref_cell_type=ref_cell_type,
+                ref_gene_key=ref_gene_key,
+                ref_raw_counts_layer=ref_raw_counts_layer,
+                **markers_from_reference_kwargs,
             )
 
-    if cell_type_key is None:
-        cell_type_key = "transferred_cell_type"
+        purity_inplace = purity_kwargs.pop("inplace", inplace)
+        cont_inplace = contamination_kwargs.pop("inplace", inplace)
+        mecr_inplace = mecr_kwargs.pop("inplace", inplace)
 
-        label_transfer_kwargs["cell_type_key"] = cell_type_key
-        label_transfer_kwargs["inplace"] = True
-
-        label_transfer_result = self.run_label_transfer(
-            adata_ref=adata_ref,
-            ref_cell_type=ref_cell_type,
-            ref_gene_key=ref_gene_key,
-            ref_raw_counts_layer=ref_raw_counts_layer,
-            **label_transfer_kwargs,
-        )
-
-    if markers is None:
-        markers = self.markers_from_reference(
-            adata=adata_ref,
-            ref_cell_type=ref_cell_type,
-            ref_gene_key=ref_gene_key,
-            ref_raw_counts_layer=ref_raw_counts_layer,
-            **markers_from_reference_kwargs,
-        )
-
-    purity_inplace = purity_kwargs.pop("inplace", inplace)
-    cont_inplace = contamination_kwargs.pop("inplace", inplace)
-    mecr_inplace = mecr_kwargs.pop("inplace", inplace)
-
-    purity_df = self.sp.marker_purity(
-        cell_type_key=cell_type_key,
-        markers=markers,
-        inplace=purity_inplace,
-        **purity_kwargs,
-    )
-
-    per_cell_cont_df, cont_frac_df, cont_count_df = (
-        self.sp.neighbor_contamination(
+        purity_df = self.sp.marker_purity(
             cell_type_key=cell_type_key,
             markers=markers,
-            inplace=cont_inplace,
-            **contamination_kwargs,
+            inplace=purity_inplace,
+            **purity_kwargs,
         )
-    )
 
-    mecr_df = self.sp.mutually_exclusive_coexpression_rate(
-        markers=markers,
-        inplace=mecr_inplace,
-        **mecr_kwargs,
-    )
+        per_cell_cont_df, cont_frac_df, cont_count_df = (
+            self.sp.neighbor_contamination(
+                cell_type_key=cell_type_key,
+                markers=markers,
+                inplace=cont_inplace,
+                **contamination_kwargs,
+            )
+        )
 
-    if inplace:
-        return None
+        mecr_df = self.sp.mutually_exclusive_coexpression_rate(
+            markers=markers,
+            inplace=mecr_inplace,
+            **mecr_kwargs,
+        )
 
-    return {
-        "label_transfer": label_transfer_result,
-        "markers": markers,
-        "marker_purity": purity_df,
-        "neighbor_contamination": {
-            "per_cell": per_cell_cont_df,
-            "fraction_mat": cont_frac_df,
-            "count_mat": cont_count_df,
-        },
-        "mutually_exclusive_coexpression_rate": mecr_df,
-    }
+        if inplace:
+            return None
+
+        return {
+            "label_transfer": label_transfer_result,
+            "markers": markers,
+            "marker_purity": purity_df,
+            "neighbor_contamination": {
+                "per_cell": per_cell_cont_df,
+                "fraction_mat": cont_frac_df,
+                "count_mat": cont_count_df,
+            },
+            "mutually_exclusive_coexpression_rate": mecr_df,
+        }
 
 
     def run_point_statistics(

--- a/src/segtraq/SegTraQ.py
+++ b/src/segtraq/SegTraQ.py
@@ -958,7 +958,7 @@ class SegTraQ:
     ):
         sp_genes = _get_genes(adata=self.sdata.tables[self.tables_key], gene_key=self.tables_gene_key)
 
-        adata = _make_ref_genes_unique(adata=adata, gene_key=ref_gene_key)
+        adata = _make_ref_genes_unique(adata, ref_gene_key=ref_gene_key)
         sc_genes = _get_genes(adata=adata, gene_key=ref_gene_key)
 
         mask = sc_genes.isin(sp_genes)

--- a/src/segtraq/SegTraQ.py
+++ b/src/segtraq/SegTraQ.py
@@ -401,6 +401,8 @@ class SegTraQ:
         *,
         adata_ref: AnnData | None = None,
         ref_cell_type: str | None = None,
+        ref_gene_key: str | None = None,
+        ref_raw_counts_layer: str | None = None,
         cell_type_key: str | None = None,
         inplace: bool = True,
         label_transfer_kwargs: dict[str, Any] | None = None,
@@ -442,6 +444,12 @@ class SegTraQ:
             Column in `adata_ref.obs` containing reference cell-type labels. Required if
             `cell_type_key=None` and label transfer should be run, or if `adata_ref` is used
             to infer `n_components`.
+        ref_gene_key : str or None, default=None
+            Column in `adata_ref.var` containing gene identifiers.
+            If `None`, `adata_ref.var_names` are used.
+        ref_raw_counts_layer : str or None, default=None
+            Layer containing raw counts. If `None`, raw counts are expected in
+            `adata.X`.
         cell_type_key : str or None, default=None
             Column in `sdata.tables[tables_key].obs` containing cell-type labels. If provided,
             this column is used for `fraction_heterotypic_overlap` and to infer ovrlpy
@@ -498,6 +506,8 @@ class SegTraQ:
             label_transfer_result = self.run_label_transfer(
                 adata_ref=adata_ref,
                 ref_cell_type=ref_cell_type,
+                ref_gene_key=ref_gene_key,
+                ref_raw_counts_layer=ref_raw_counts_layer,
                 **label_transfer_kwargs,
             )
 
@@ -683,6 +693,8 @@ class SegTraQ:
         *,
         adata_ref: AnnData | None = None,
         ref_cell_type: str | None = None,
+        ref_gene_key: str | None = None,
+        ref_raw_counts_layer: str | None = None,
         markers: dict[str, dict[str, list[str]]] | None = None,
         cell_type_key: str | None = None,
         inplace: bool = True,
@@ -718,6 +730,12 @@ class SegTraQ:
         ref_cell_type : str or None, default=None
             Column in `adata_ref.obs` containing reference cell-type labels.
             Required if `cell_type_key=None` or `markers=None`.
+        ref_gene_key : str or None, default=None
+            Column in `adata_ref.var` containing gene identifiers.
+            If `None`, `adata_ref.var_names` are used.
+        ref_raw_counts_layer : str or None, default=None
+            Layer containing raw counts. If `None`, raw counts are expected in
+            `adata.X`.
         markers : dict or None, default=None
             Dictionary of marker genes in the form
             `{cell_type: {"positive": list[str], "negative": list[str]}}`.
@@ -755,82 +773,100 @@ class SegTraQ:
             `"marker_purity"`, `"neighbor_contamination"`, and
             `"mutually_exclusive_coexpression_rate"`.
         """
-        label_transfer_kwargs = {} if label_transfer_kwargs is None else dict(label_transfer_kwargs)
-        markers_from_reference_kwargs = (
-            {} if markers_from_reference_kwargs is None else dict(markers_from_reference_kwargs)
-        )
-        purity_kwargs = {} if purity_kwargs is None else dict(purity_kwargs)
-        contamination_kwargs = {} if contamination_kwargs is None else dict(contamination_kwargs)
-        mecr_kwargs = {} if mecr_kwargs is None else dict(mecr_kwargs)
+    label_transfer_kwargs = (
+        {} if label_transfer_kwargs is None else dict(label_transfer_kwargs)
+    )
+    markers_from_reference_kwargs = (
+        {} if markers_from_reference_kwargs is None
+        else dict(markers_from_reference_kwargs)
+    )
+    purity_kwargs = {} if purity_kwargs is None else dict(purity_kwargs)
+    contamination_kwargs = (
+        {} if contamination_kwargs is None else dict(contamination_kwargs)
+    )
+    mecr_kwargs = {} if mecr_kwargs is None else dict(mecr_kwargs)
 
-        label_transfer_result = None
+    label_transfer_result = None
 
-        needs_reference = cell_type_key is None or markers is None
+    needs_reference = cell_type_key is None or markers is None
 
-        if needs_reference:
-            if adata_ref is None:
-                raise ValueError("`adata_ref` is required when `cell_type_key=None` or `markers=None`.")
-
-            if ref_cell_type is None:
-                raise ValueError("`ref_cell_type` is required when `cell_type_key=None` or `markers=None`.")
-
-        if cell_type_key is None:
-            cell_type_key = "transferred_cell_type"
-
-            label_transfer_kwargs["cell_type_key"] = cell_type_key
-            label_transfer_kwargs["inplace"] = True
-
-            label_transfer_result = self.run_label_transfer(
-                adata_ref=adata_ref,
-                ref_cell_type=ref_cell_type,
-                **label_transfer_kwargs,
+    if needs_reference:
+        if adata_ref is None:
+            raise ValueError(
+                "`adata_ref` is required when "
+                "`cell_type_key=None` or `markers=None`."
             )
 
-        if markers is None:
-            markers = self.markers_from_reference(
-                adata=adata_ref,
-                ref_cell_type=ref_cell_type,
-                **markers_from_reference_kwargs,
+        if ref_cell_type is None:
+            raise ValueError(
+                "`ref_cell_type` is required when "
+                "`cell_type_key=None` or `markers=None`."
             )
 
-        purity_inplace = purity_kwargs.pop("inplace", inplace)
-        cont_inplace = contamination_kwargs.pop("inplace", inplace)
-        mecr_inplace = mecr_kwargs.pop("inplace", inplace)
+    if cell_type_key is None:
+        cell_type_key = "transferred_cell_type"
 
-        purity_df = self.sp.marker_purity(
-            cell_type_key=cell_type_key,
-            markers=markers,
-            inplace=purity_inplace,
-            **purity_kwargs,
+        label_transfer_kwargs["cell_type_key"] = cell_type_key
+        label_transfer_kwargs["inplace"] = True
+
+        label_transfer_result = self.run_label_transfer(
+            adata_ref=adata_ref,
+            ref_cell_type=ref_cell_type,
+            ref_gene_key=ref_gene_key,
+            ref_raw_counts_layer=ref_raw_counts_layer,
+            **label_transfer_kwargs,
         )
 
-        per_cell_cont_df, cont_mat_df, cont_bin_df = self.sp.neighbor_contamination(
+    if markers is None:
+        markers = self.markers_from_reference(
+            adata=adata_ref,
+            ref_cell_type=ref_cell_type,
+            ref_gene_key=ref_gene_key,
+            ref_raw_counts_layer=ref_raw_counts_layer,
+            **markers_from_reference_kwargs,
+        )
+
+    purity_inplace = purity_kwargs.pop("inplace", inplace)
+    cont_inplace = contamination_kwargs.pop("inplace", inplace)
+    mecr_inplace = mecr_kwargs.pop("inplace", inplace)
+
+    purity_df = self.sp.marker_purity(
+        cell_type_key=cell_type_key,
+        markers=markers,
+        inplace=purity_inplace,
+        **purity_kwargs,
+    )
+
+    per_cell_cont_df, cont_frac_df, cont_count_df = (
+        self.sp.neighbor_contamination(
             cell_type_key=cell_type_key,
             markers=markers,
             inplace=cont_inplace,
             **contamination_kwargs,
         )
+    )
 
-        mecr_df = self.sp.mutually_exclusive_coexpression_rate(
-            markers=markers,
-            inplace=mecr_inplace,
-            **mecr_kwargs,
-        )
+    mecr_df = self.sp.mutually_exclusive_coexpression_rate(
+        markers=markers,
+        inplace=mecr_inplace,
+        **mecr_kwargs,
+    )
 
-        if inplace:
-            return None
+    if inplace:
+        return None
 
-        return {
-            "label_transfer": label_transfer_result,
-            "markers": markers,
-            "marker_purity": purity_df,
-            "neighbor_contamination": {
-                "per_cell": per_cell_cont_df,
-                "matrix": cont_mat_df,
-                "binary_matrix": cont_bin_df,
-            },
-            "mutually_exclusive_coexpression_rate": mecr_df,
-        }
+    return {
+        "label_transfer": label_transfer_result,
+        "markers": markers,
+        "marker_purity": purity_df,
+        "neighbor_contamination": {
+            "per_cell": per_cell_cont_df,
+            "fraction_mat": cont_frac_df,
+            "count_mat": cont_count_df,
+        },
+        "mutually_exclusive_coexpression_rate": mecr_df,
+    }
+
 
     def run_point_statistics(
         self,

--- a/src/segtraq/SegTraQ.py
+++ b/src/segtraq/SegTraQ.py
@@ -8,7 +8,7 @@ from anndata import AnnData
 
 from . import bl, cs, pl, ps, rs, sp, vl
 from .constants import SEGTRAQ_CELL_ID_KEY
-from .utils import _filter_control_and_low_quality_transcripts, _get_genes, validate_spatialdata
+from .utils import _filter_control_and_low_quality_transcripts, _get_genes, _make_ref_genes_unique, validate_spatialdata
 from .utils import filter_cells as _filter_cells
 from .utils import markers_from_reference as _markers_from_reference
 from .utils import run_label_transfer as _run_label_transfer
@@ -958,6 +958,7 @@ class SegTraQ:
     ):
         sp_genes = _get_genes(adata=self.sdata.tables[self.tables_key], gene_key=self.tables_gene_key)
 
+        _make_ref_genes_unique(adata=adata, gene_key=ref_gene_key)
         sc_genes = _get_genes(adata=adata, gene_key=ref_gene_key)
 
         mask = sc_genes.isin(sp_genes)

--- a/src/segtraq/utils.py
+++ b/src/segtraq/utils.py
@@ -368,47 +368,35 @@ def _get_genes(
 
     return genes
 
-
 def _make_ref_genes_unique(
     adata_ref: AnnData,
     ref_gene_key: str | None = None,
 ) -> AnnData:
     """
-    Ensure gene identifiers are unique in the AnnData object.
+    Ensure gene identifiers used as var_names are unique.
 
-    If `ref_gene_key is None`, makes `adata_ref.var_names` unique in place.
-    If `ref_gene_key` is provided, drops duplicated genes, keeping the first.
+    If `ref_gene_key` is provided, use `adata_ref.var[ref_gene_key]`
+    as `var_names`. Duplicate identifiers are made unique using
+    `var_names_make_unique()`.
     """
     adata_ref = adata_ref.copy()
 
-    if ref_gene_key is None:
-        if not adata_ref.var_names.is_unique:
-            warnings.warn(
-                "`adata_ref.var_names` are not unique. Making them unique with `adata_ref.var_names_make_unique()`.",
-                UserWarning,
-                stacklevel=2,
-            )
-            adata_ref.var_names_make_unique()
-        return adata_ref
+    if ref_gene_key is not None:
+        if ref_gene_key not in adata_ref.var.columns:
+            raise KeyError(f"'{ref_gene_key}' not found in `adata_ref.var`.")
 
-    if ref_gene_key not in adata_ref.var.columns:
-        raise KeyError(f"'{ref_gene_key}' not found in `adata_ref.var`.")
+        adata_ref.var_names = adata_ref.var[ref_gene_key].astype(str)
 
-    genes = pd.Index(adata_ref.var[ref_gene_key].values)
-
-    if genes.duplicated().any():
-        n_dup = genes.duplicated().sum()
+    if not adata_ref.var_names.is_unique:
         warnings.warn(
-            f"`adata_ref.var[{ref_gene_key!r}]` contains {n_dup} duplicated entries. "
-            "Dropping duplicate genes, keeping the first occurrence.",
+            "Gene identifiers are not unique. Making them unique with "
+            "`adata_ref.var_names_make_unique()`.",
             UserWarning,
             stacklevel=2,
         )
-        keep = ~genes.duplicated()
-        adata_ref = adata_ref[:, keep].copy()
+        adata_ref.var_names_make_unique()
 
     return adata_ref
-
 
 def run_label_transfer(
     sdata,
@@ -502,6 +490,7 @@ def run_label_transfer(
         `tables_cell_id_key`, `cell_type_key`, and `"pearson_score"`.
         If `inplace=True`, modifies `sdata` in place and returns `None`.
     """
+    # copies gene identifiers into var_names and makes them unique (if needed)
     adata_ref = _make_ref_genes_unique(adata_ref, ref_gene_key=ref_gene_key)
 
     if ref_cell_type not in adata_ref.obs.columns:
@@ -552,7 +541,7 @@ def run_label_transfer(
     adata_ref = _get_norm_log(adata_ref, layer=ref_raw_counts_layer)
     adata_q = _get_norm_log(adata_q, layer=tables_raw_counts_layer)
 
-    genes = _get_genes(adata_ref, ref_gene_key)
+    genes = adata_ref.var_names
 
     norm_log_counts = _to_ndarray(adata_ref.layers[NORM_LOG_LAYER])
     celltypes = adata_ref.obs[ref_cell_type]
@@ -871,10 +860,11 @@ def markers_from_reference(
         A dictionary mapping each cell type to its positive and negative markers:
         {cell_type: {"positive": [genes], "negative": [genes]}}
     """
+    # copies gene identifiers into var_names and makes them unique (if needed)
     adata = _make_ref_genes_unique(adata, ref_gene_key=ref_gene_key)
 
     # getting gene names and mapping to indices for later use
-    var_names = _get_genes(adata, ref_gene_key)
+    var_names = adata.var_names
     gene_to_idx = {g: i for i, g in enumerate(var_names)}
 
     # raw counts for expression fraction computation (must be before normalization)
@@ -892,6 +882,7 @@ def markers_from_reference(
 
     # Cell counts per type -> filter rare cell types from pairwise contrasts
     cell_counts = ctypes.value_counts().to_dict()
+
     usable_celltypes = [ct for ct in types if cell_counts.get(ct, 0) >= min_cells_per_celltype]
     n_celltypes = len(usable_celltypes)
     if n_celltypes < 2:
@@ -910,6 +901,7 @@ def markers_from_reference(
     for ct in usable_celltypes:
         mask_ct = ctypes == ct
         X_ct = counts[mask_ct]
+
         if sparse.issparse(X_ct):
             frac = X_ct.getnnz(axis=0) / X_ct.shape[0]
         else:

--- a/src/segtraq/utils.py
+++ b/src/segtraq/utils.py
@@ -364,9 +364,10 @@ def _get_genes(
         genes = pd.Index(adata.var[gene_key].values)
 
     if genes.duplicated().any():
-        raise ValueError(f"Gene identifiers in are not unique.")
+        raise ValueError("Gene identifiers in are not unique.")
 
     return genes
+
 
 def _make_ref_genes_unique(
     adata_ref: AnnData,
@@ -383,9 +384,9 @@ def _make_ref_genes_unique(
     if ref_gene_key is None:
         if not adata_ref.var_names.is_unique:
             warnings.warn(
-                "`adata_ref.var_names` are not unique. Making them unique with "
-                "`adata_ref.var_names_make_unique()`.",
+                "`adata_ref.var_names` are not unique. Making them unique with `adata_ref.var_names_make_unique()`.",
                 UserWarning,
+                stacklevel=2,
             )
             adata_ref.var_names_make_unique()
         return adata_ref
@@ -401,11 +402,13 @@ def _make_ref_genes_unique(
             f"`adata_ref.var[{ref_gene_key!r}]` contains {n_dup} duplicated entries. "
             "Dropping duplicate genes, keeping the first occurrence.",
             UserWarning,
+            stacklevel=2,
         )
         keep = ~genes.duplicated()
         adata_ref = adata_ref[:, keep].copy()
 
     return adata_ref
+
 
 def run_label_transfer(
     sdata,

--- a/src/segtraq/utils.py
+++ b/src/segtraq/utils.py
@@ -364,7 +364,7 @@ def _get_genes(
         genes = pd.Index(adata.var[gene_key].values)
 
     if genes.duplicated().any():
-        raise ValueError("Gene identifiers in are not unique.")
+        raise ValueError("Gene identifiers are not unique.")
 
     return genes
 


### PR DESCRIPTION
While adding UX improvements to the Viash components, I identified and fixed a bug in label transfer / marker extraction:

- `scanpy.rank_genes_groups()` uses `adata.var_names`, so when `ref_gene_key` differed from `var_names`, no overlapping genes were found with the query data.
- Added `_make_ref_genes_unique()`, which sets `adata.var_names = adata.var[ref_gene_key]` and makes them unique. This is necessary because reference scRNA-seq data often contain duplicated gene symbols, while matching identifiers must be used across `tables_gene_key`, `points_gene_key`, and `ref_gene_key`.
- Exposed `ref_gene_key` and `ref_raw_counts_layer` in `run_supervised()` and `run_volume()` to simplify usage.