### PR TITLE
implemented new merge_into_uns function

### DIFF
--- a/src/segtraq/bl/baseline.py
+++ b/src/segtraq/bl/baseline.py
@@ -7,7 +7,7 @@ import spatialdata as sd
 from joblib import Parallel, delayed
 from shapely.geometry import MultiPolygon, Polygon
 
-from ..utils import _get_genes, _is_background, merge_into_obs, merge_into_var
+from ..utils import _get_genes, _is_background, merge_into_obs, merge_into_uns, merge_into_var
 from .utils import count_polygons
 
 
@@ -32,7 +32,7 @@ def num_cells(sdata: sd.SpatialData, tables_key: str = "table", inplace: bool = 
     """
     num_cells = len(sdata.tables[tables_key])
     if inplace:
-        sdata.tables[tables_key].uns["num_cells"] = num_cells
+        merge_into_uns(sdata, tables_key=tables_key, updates={"num_cells": num_cells})
     return num_cells
 
 
@@ -62,7 +62,7 @@ def num_transcripts(
     points = points.compute() if hasattr(points, "compute") else points
     num_transcripts = len(points)
     if inplace:
-        sdata.tables[tables_key].uns["num_transcripts"] = num_transcripts
+        merge_into_uns(sdata, tables_key=tables_key, updates={"num_transcripts": num_transcripts})
 
     return num_transcripts
 
@@ -111,18 +111,18 @@ def num_genes(
     if num_genes_points != num_genes_adata:
         genes_not_in_points = set(genes_adata) - set(points[points_gene_key].unique())
         genes_not_in_adata = set(points[points_gene_key].unique()) - set(genes_adata)
-        genes_not_in_both = genes_not_in_points.union(genes_not_in_adata)
+        genes_not_in_both = list(genes_not_in_points.union(genes_not_in_adata))
         warnings.warn(
             f"The number of genes differs between points ({num_genes_points}) and tables ({num_genes_adata}). "
-            f"Example genes that are missed: {list(genes_not_in_both)}."
+            f"Example genes that are missed: {genes_not_in_both[: min(5, len(genes_not_in_both))]}. "
             f"If these are control probes, please make sure to include them in the SegTraQ constructor. "
             "For example: SegTraQ(filter_kwargs={'control_prefixes': [...], 'control_genes': [...]}). "
-            f"Storing the number of genes from the points layer, but please check the warning message for details.",
+            f"Storing the number of genes from the points layer.",
             stacklevel=2,
         )
 
     if inplace:
-        sdata.tables[tables_key].uns["num_genes"] = num_genes_points
+        merge_into_uns(sdata, tables_key=tables_key, updates={"num_genes": num_genes_points})
 
     return num_genes_points
 
@@ -166,7 +166,9 @@ def perc_unassigned_transcripts(
     perc_unassigned_transcripts = is_background.mean() * 100
 
     if inplace:
-        sdata.tables[tables_key].uns["perc_unassigned_transcripts"] = perc_unassigned_transcripts
+        merge_into_uns(
+            sdata, tables_key=tables_key, updates={"perc_unassigned_transcripts": perc_unassigned_transcripts}
+        )
 
     # converting from np.float to float
     return float(perc_unassigned_transcripts)

--- a/src/segtraq/cs/clustering_stability.py
+++ b/src/segtraq/cs/clustering_stability.py
@@ -4,7 +4,7 @@ import spatialdata as sd
 from sklearn.metrics import silhouette_score as _silhouette_score
 
 from ..constants import CONNECTIVITIES_KEY, NEIGHBORS_KEY, PCA_KEY
-from ..utils import _get_pca_and_neighbors
+from ..utils import _get_pca_and_neighbors, merge_into_uns
 from .utils import (
     _cluster_connectedness,
     ari_mean,
@@ -131,7 +131,7 @@ def cluster_connectedness(
                 best_distance = float(distance_val)
 
     if inplace:
-        sdata.tables[tables_key].uns["cluster_connectedness"] = best_distance
+        merge_into_uns(sdata, tables_key=tables_key, updates={"cluster_connectedness": best_distance})
 
     return best_distance
 
@@ -218,7 +218,7 @@ def silhouette_score(
 
             # handle inplace within the branch and return early, avoiding fall-through
             if inplace:
-                sdata.tables[tables_key].uns[key] = best_silhouette_score
+                merge_into_uns(sdata, tables_key=tables_key, updates={key: best_silhouette_score})
             return best_silhouette_score
         else:
             raise ValueError(f"cell_type_key '{cell_type_key}' must contain more than one cluster")
@@ -257,7 +257,7 @@ def silhouette_score(
                     best_silhouette_score = float(silhouette_avg)
 
     if inplace and key is not None:
-        sdata.tables[tables_key].uns[key] = best_silhouette_score
+        merge_into_uns(sdata, tables_key=tables_key, updates={key: best_silhouette_score})
 
     return best_silhouette_score
 
@@ -319,7 +319,7 @@ def purity(
     mean_purity = float(purity_mean(purity_matrix))
 
     if inplace:
-        sdata.tables[tables_key].uns["mean_purity"] = mean_purity
+        merge_into_uns(sdata, tables_key=tables_key, updates={"mean_purity": mean_purity})
 
     return mean_purity
 
@@ -382,6 +382,6 @@ def adjusted_rand_index(
     mean_ari = float(ari_mean(pairwise_aris))
 
     if inplace:
-        sdata.tables[tables_key].uns["mean_ari"] = mean_ari
+        merge_into_uns(sdata, tables_key=tables_key, updates={"mean_ari": mean_ari})
 
     return mean_ari

--- a/src/segtraq/ps/point_statistics.py
+++ b/src/segtraq/ps/point_statistics.py
@@ -157,6 +157,9 @@ def percentage_transcripts_in_compartments(
             inplace=True,
         )
 
+    # refetching the table after modification
+    tbl = sdata.tables[tables_key]
+
     # map each cell_id to its best nucleus id
     cell_to_nuc = tbl.obs[[tables_cell_id_key, "nucleus_id"]].copy()
     cell_to_nuc = cell_to_nuc.dropna(subset=["nucleus_id"])

--- a/src/segtraq/sp/supervised.py
+++ b/src/segtraq/sp/supervised.py
@@ -7,7 +7,7 @@ import squidpy as sq
 from scipy import sparse
 from scipy.stats import fisher_exact
 
-from ..utils import _get_count_matrix, _get_genes, merge_into_obs
+from ..utils import _get_count_matrix, _get_genes, merge_into_obs, merge_into_uns
 
 
 def mutually_exclusive_coexpression_rate(
@@ -446,8 +446,11 @@ def neighbor_contamination(
             tables_cell_id_key=tables_cell_id_key,
             df_cell_id_key=tables_cell_id_key,
         )
-        sdata.tables[tables_key].uns[uns_key] = contamination_matrix_df
-        sdata.tables[tables_key].uns[uns_key_binary] = contamination_binary_df
+        merge_into_uns(
+            sdata,
+            tables_key=tables_key,
+            updates={uns_key: contamination_matrix_df, uns_key_binary: contamination_binary_df},
+        )
 
     return per_cell_df, contamination_matrix_df, contamination_binary_df
 

--- a/src/segtraq/utils.py
+++ b/src/segtraq/utils.py
@@ -527,6 +527,8 @@ def run_label_transfer(
             points_gene_key=points_gene_key,
             tables_key=tables_key,
         )
+        # refetching the table after modification
+        tbl = sdata.tables[tables_key]
 
     qc_range = {
         "transcript_count": (tx_min, tx_max),
@@ -556,7 +558,7 @@ def run_label_transfer(
 
     norm_log_counts_df = pd.DataFrame(norm_log_counts, columns=genes)
     norm_log_counts_df["celltype"] = celltypes.values
-    ref_mean_df = norm_log_counts_df.groupby("celltype").mean()
+    ref_mean_df = norm_log_counts_df.groupby("celltype", observed=True).mean()
 
     genes_to_use = None
 
@@ -592,6 +594,7 @@ def run_label_transfer(
     )
 
     out = ct_corr.rename(columns={"transferred_cell_type": cell_type_key})
+    out[cell_type_key] = out[cell_type_key].astype("category")
 
     if inplace:
         merge_into_obs(
@@ -601,15 +604,19 @@ def run_label_transfer(
             tables_cell_id_key=tables_cell_id_key,
             df_cell_id_key=tables_cell_id_key,
         )
-        tbl.obs[cell_type_key] = tbl.obs[cell_type_key].astype("category")
         return None
 
     return out
 
 
 def merge_into_obs(
-    sdata, tables_key, df_to_merge: pd.DataFrame, tables_cell_id_key: str, df_cell_id_key: str, fillna_cols=None
-):
+    sdata,
+    tables_key: str,
+    df_to_merge: pd.DataFrame,
+    tables_cell_id_key: str,
+    df_cell_id_key: str,
+    fillna_cols=None,
+) -> None:
     """
     Left-join df_to_merge into sdata.tables[tables_key].obs without resetting the index
     and without creating duplicate key columns.
@@ -617,7 +624,8 @@ def merge_into_obs(
     - Uses obs[tables_cell_id_key] as the join key
     - Drops overlapping columns on the right before joining
     """
-    obs = sdata.tables[tables_key].obs
+    table = sdata.tables[tables_key].copy()
+    obs = table.obs
 
     # Temporarily clear the index name to avoid pandas ambiguity when
     # tables_cell_id_key is both a column and the index name
@@ -626,14 +634,12 @@ def merge_into_obs(
 
     # Build right indexed by the join key
     right = df_to_merge.set_index(df_cell_id_key, drop=True)
-
     # Drop overlapping columns from obs to avoid duplicates
     overlapping_cols = [c for c in right.columns if c in obs.columns]
     if overlapping_cols:
         obs = obs.drop(columns=overlapping_cols)
 
     joined = obs.join(right, on=tables_cell_id_key, how="left")
-
     # Restore the original index name
     joined.index.name = original_index_name
 
@@ -643,20 +649,55 @@ def merge_into_obs(
             if c in joined.columns:
                 joined[c] = joined[c].fillna(0)
 
-    sdata.tables[tables_key].obs = joined
+    table.obs = joined
+    sdata.tables[tables_key] = table
 
 
-def merge_into_var(sdata, tables_key, df_to_merge):
-    var = sdata.tables[tables_key].var
+def merge_into_var(
+    sdata,
+    tables_key: str,
+    df_to_merge: pd.DataFrame,
+) -> None:
+    """
+    Left-join df_to_merge into sdata.tables[tables_key].var by index.
+    Drops overlapping columns before joining to avoid duplicates.
+    """
+    table = sdata.tables[tables_key].copy()
+    var = table.var
 
     overlapping = [c for c in df_to_merge.columns if c in var.columns]
-
     if overlapping:
         var = var.drop(columns=overlapping)
 
-    df = var.merge(df_to_merge, left_index=True, right_index=True, how="left")
+    table.var = var.merge(df_to_merge, left_index=True, right_index=True, how="left")
+    sdata.tables[tables_key] = table
 
-    sdata.tables[tables_key].var = df
+
+def merge_into_uns(
+    sdata,
+    tables_key: str,
+    updates: dict,
+    overwrite: bool = True,
+) -> None:
+    """
+    Merge a dict of key-value pairs into sdata.tables[tables_key].uns.
+
+    Parameters
+    ----------
+    updates : dict
+        Key-value pairs to write into uns.
+    overwrite : bool
+        If False, existing keys are left untouched. Default is True.
+    """
+    table = sdata.tables[tables_key].copy()
+
+    if overwrite:
+        table.uns.update(updates)
+    else:
+        for k, v in updates.items():
+            table.uns.setdefault(k, v)
+
+    sdata.tables[tables_key] = table
 
 
 def _pairwise_auc(


### PR DESCRIPTION
Addresses #172. We previously had a bunch of implicit modifications in the code. I modified the existing merge functions, so that they now explicitly reassign `sdata.tables['table'] = adata`. This should help to avoid some weird behaviors due to adata being a view in the future. While implementing this, I actually already found a couple of issues that were due to this old pattern, these are fixed now.