### PR TITLE
Added a query_gene_key to run_label_transfer.

### DIFF
--- a/src/segtraq/SegTraQ.py
+++ b/src/segtraq/SegTraQ.py
@@ -403,6 +403,7 @@ class SegTraQ:
         adata_ref: AnnData | None = None,
         ref_cell_type: str | None = None,
         ref_gene_key: str | None = None,
+        query_gene_key: str | None = None,
         ref_raw_counts_layer: str | None = None,
         cell_type_key: str | None = None,
         inplace: bool = True,
@@ -448,6 +449,9 @@ class SegTraQ:
         ref_gene_key : str or None, default=None
             Column in `adata_ref.var` containing gene identifiers.
             If `None`, `adata_ref.var_names` are used.
+        query_gene_key : str or None, default=None
+            Column in `sdata.tables[tables_key].var` containing gene identifiers matching
+            `adata_ref.var[ref_gene_key]`. If `None`, `sdata.tables[tables_key].var_names` are used.
         ref_raw_counts_layer : str or None, default=None
             Layer containing raw counts. If `None`, raw counts are expected in
             `adata.X`.
@@ -508,6 +512,7 @@ class SegTraQ:
                 adata_ref=adata_ref,
                 ref_cell_type=ref_cell_type,
                 ref_gene_key=ref_gene_key,
+                query_gene_key=query_gene_key,
                 ref_raw_counts_layer=ref_raw_counts_layer,
                 **label_transfer_kwargs,
             )
@@ -695,6 +700,7 @@ class SegTraQ:
         adata_ref: AnnData | None = None,
         ref_cell_type: str | None = None,
         ref_gene_key: str | None = None,
+        query_gene_key: str | None = None,
         ref_raw_counts_layer: str | None = None,
         markers: dict[str, dict[str, list[str]]] | None = None,
         cell_type_key: str | None = None,
@@ -734,6 +740,9 @@ class SegTraQ:
         ref_gene_key : str or None, default=None
             Column in `adata_ref.var` containing gene identifiers.
             If `None`, `adata_ref.var_names` are used.
+        query_gene_key : str or None, default=None
+            Column in `sdata.tables[tables_key].var` containing gene identifiers matching
+            `adata_ref.var[ref_gene_key]`. If `None`, `sdata.tables[tables_key].var_names` are used.
         ref_raw_counts_layer : str or None, default=None
             Layer containing raw counts. If `None`, raw counts are expected in
             `adata.X`.
@@ -803,6 +812,7 @@ class SegTraQ:
                 adata_ref=adata_ref,
                 ref_cell_type=ref_cell_type,
                 ref_gene_key=ref_gene_key,
+                query_gene_key=query_gene_key,
                 ref_raw_counts_layer=ref_raw_counts_layer,
                 **label_transfer_kwargs,
             )
@@ -1025,6 +1035,7 @@ class SegTraQ:
         adata_ref: AnnData,
         ref_cell_type: str,
         ref_gene_key: str | None = None,
+        query_gene_key: str | None = None,
         ref_raw_counts_layer: str | None = "raw",
         tx_min: float = 10.0,
         tx_max: float = float("inf"),
@@ -1046,9 +1057,9 @@ class SegTraQ:
             ref_cell_type=ref_cell_type,
             ref_raw_counts_layer=ref_raw_counts_layer,
             ref_gene_key=ref_gene_key,
+            query_gene_key=query_gene_key,
             tables_key=self.tables_key,
             tables_cell_id_key=self.tables_cell_id_key,
-            tables_gene_key=self.tables_gene_key,
             tables_raw_counts_layer=self.tables_raw_counts_layer,
             points_key=self.points_key,
             points_cell_id_key=self.points_cell_id_key,

--- a/src/segtraq/utils.py
+++ b/src/segtraq/utils.py
@@ -414,7 +414,7 @@ def run_label_transfer(
     ref_raw_counts_layer: str | None = "raw",
     tables_key: str = "table",
     tables_cell_id_key: str = "cell_id",
-    tables_gene_key: str | None = None,
+    query_gene_key: str | None = None,
     points_key: str = "transcripts",
     points_cell_id_key: str = "cell_id",
     points_gene_key: str = "feature_name",
@@ -457,9 +457,9 @@ def run_label_transfer(
         Key identifying the cell-level AnnData table in `sdata.tables`.
     tables_cell_id_key : str, default="cell_id"
         Column in `sdata.tables[tables_key].obs` containing unique cell identifiers.
-    tables_gene_key : str or None, default=None
-        Column in `sdata.tables[tables_key].var` containing gene identifiers.
-        If `None`, `sdata.tables[tables_key].var_names` are used.
+    query_gene_key : str or None, default=None
+        Column in `sdata.tables[tables_key].var` containing gene identifiers matching
+        `adata_ref.var[ref_gene_key]`. If `None`, `sdata.tables[tables_key].var_names` are used.
     points_key : str, default="transcripts"
         Key identifying the transcript-level points element in `sdata.points`.
     points_cell_id_key : str, default="cell_id"
@@ -588,7 +588,7 @@ def run_label_transfer(
     ct_corr = _assign_celltype_by_pearson(
         adata=adata_q,
         ref_mean_df=ref_mean_df,
-        tables_gene_key=tables_gene_key,
+        tables_gene_key=query_gene_key,
         tables_cell_id_key=tables_cell_id_key,
         genes_to_use=genes_to_use,
     )


### PR DESCRIPTION
`tables_gene_key` used during SegTraQ initialization has to match `points_gene_key`. However, in `run_label_transfer`, the gene key has to match the gene key from the reference scRNA-seq dataset. I added an independent parameter `query_gene_key` to `run_label_transfer`. 