### PR TITLE
Bugfix in vl module - disable equal top and bottom thresholds

### DIFF
--- a/docs/notebooks/io.ipynb
+++ b/docs/notebooks/io.ipynb
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "9dcbd8e9",
    "metadata": {
     "tags": []
@@ -52,6 +52,7 @@
     "from rasterio.features import shapes\n",
     "from shapely.geometry import shape\n",
     "from scipy.sparse import csr_matrix\n",
+    "from spatialdata.models import PointsModel\n",
     "from spatialdata.transformations import (\n",
     "    get_transformation,\n",
     "    set_transformation,\n",
@@ -795,6 +796,38 @@
   },
   {
    "cell_type": "markdown",
+   "id": "47101def",
+   "metadata": {},
+   "source": [
+    "Proseg applies clipping to the transcript z-coordinates and overwrites the original values in `observed_z`. To preserve the raw Xenium z-coordinates for downstream analyses, we map the original `z` values back to the Proseg transcript table using the unique `transcript_id`. See more info in this [issue](https://github.com/dcjones/proseg/issues/136)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ed3a21f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "proseg_tx = sdata_proseg2.points[\"transcripts\"].compute()\n",
+    "proseg_tx = proseg_tx.reset_index(drop=True)\n",
+    "xenium_tx = sdata_xenium.points[\"transcripts\"].compute()\n",
+    "xenium_tx = xenium_tx.reset_index(drop=True)\n",
+    "\n",
+    "proseg_tx[\"z\"] = (proseg_tx[\"transcript_id\"].map(xenium_tx.set_index(\"transcript_id\")[\"z\"]))\n",
+    "\n",
+    "transformation = sdata_proseg2.points[\"transcripts\"].attrs[\"transform\"]\n",
+    "\n",
+    "sdata_proseg2.points[\"transcripts\"] = PointsModel.parse(\n",
+    "    proseg_tx,\n",
+    "    coordinates={\"x\": \"x\", \"y\": \"y\", \"z\": \"z\"},\n",
+    ")\n",
+    "\n",
+    "sdata_proseg2.points[\"transcripts\"].attrs[\"transform\"] = transformation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "1de214e7",
    "metadata": {},
    "source": [
@@ -1071,6 +1104,38 @@
     "        set_transformation(shape_layer, xenium_transformation)\n",
     "\n",
     "set_transformation(sdata_proseg3.points[\"transcripts\"], xenium_transformation)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "509ae545",
+   "metadata": {},
+   "source": [
+    "Proseg applies clipping to the transcript z-coordinates and overwrites the original values in `observed_z`. To preserve the raw Xenium z-coordinates for downstream analyses, we map the original `z` values back to the Proseg transcript table using the unique `transcript_id`. See more info in this [issue](https://github.com/dcjones/proseg/issues/136)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "096a6cd8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "proseg_tx = sdata_proseg3.points[\"transcripts\"].compute()\n",
+    "proseg_tx = proseg_tx.reset_index(drop=True)\n",
+    "xenium_tx = sdata_xenium.points[\"transcripts\"].compute()\n",
+    "xenium_tx = xenium_tx.reset_index(drop=True)\n",
+    "\n",
+    "proseg_tx[\"z\"] = (proseg_tx[\"transcript_id\"].map(xenium_tx.set_index(\"transcript_id\")[\"z\"]))\n",
+    "\n",
+    "transformation = sdata_proseg3.points[\"transcripts\"].attrs[\"transform\"]\n",
+    "\n",
+    "sdata_proseg3.points[\"transcripts\"] = PointsModel.parse(\n",
+    "    proseg_tx,\n",
+    "    coordinates={\"x\": \"x\", \"y\": \"y\", \"z\": \"z\"},\n",
+    ")\n",
+    "\n",
+    "sdata_proseg3.points[\"transcripts\"].attrs[\"transform\"] = transformation"
    ]
   },
   {
@@ -1412,7 +1477,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "segtraq_26",
+   "display_name": "segtraq_py311 (3.11.13)",
    "language": "python",
    "name": "python3"
   },

--- a/src/segtraq/vl/utils.py
+++ b/src/segtraq/vl/utils.py
@@ -14,11 +14,10 @@ def _correct_z_drift(
     seed: int | None = 0,
 ) -> np.ndarray:
     """
-    Global z-drift correction (tilt regression + clipping + [0,1] scaling).
+    Global z-drift correction (tilt regression).
 
     This function removes global z-tilt by fitting a plane z ~ x + y and replacing
-    z with the residuals. It then clips extreme residuals to avoid outliers defining
-    the depth range and rescales the result to [0,1].
+    z with the residuals. 
 
     Parameters
     ----------
@@ -34,7 +33,6 @@ def _correct_z_drift(
     Returns
     -------
     z_corr : np.ndarray
-        Corrected and normalized z values in [0,1], same length/order as `tx`.
     """
     x = tx[points_x_key].to_numpy(dtype=float)
     y = tx[points_y_key].to_numpy(dtype=float)

--- a/src/segtraq/vl/volume.py
+++ b/src/segtraq/vl/volume.py
@@ -258,8 +258,17 @@ def similarity_top_bottom(
         lambda s: s.quantile(1.0 - q)
     )
 
-    tx["_is_bottom"] = z <= tx["_z_bottom"]
-    tx["_is_top"] = z >= tx["_z_top"]
+    valid_split = tx["_z_bottom"] < tx["_z_top"]
+
+    tx["_is_bottom"] = (
+        valid_split
+        & (tx["_z_for_split"] <= tx["_z_bottom"])
+    )
+
+    tx["_is_top"] = (
+        valid_split
+        & (tx["_z_for_split"] >= tx["_z_top"])
+    )
 
     # counts per part
     counts_bottom = (


### PR DESCRIPTION
Added a validity check requiring the bottom quantile threshold to be strictly lower than the top threshold before assigning transcripts to either group. This prevents cells with identical top and bottom thresholds—typically caused by clipped z coordinates through Proseg —from using the same transcripts for both profiles and producing artificially high cosine similarity.

Additionally, the `io.ipynb` was updated to preserve original z-coordinates in proseg sdata and a github issue was raised:
https://github.com/dcjones/proseg/issues/136