### PR TITLE
disabled bootstrapping by default

### DIFF
--- a/src/segtraq/rs/region_similarity.py
+++ b/src/segtraq/rs/region_similarity.py
@@ -869,7 +869,7 @@ def border_admixture_score(
     min_transcripts: int = 10,
     min_genes: int = 5,
     pseudocount: float = 0.5,
-    n_boot: int = 200,
+    n_boot: int = 0,
     ci_level: float = 0.95,
     random_state: int | None = None,
     n_jobs: int = -1,
@@ -885,7 +885,7 @@ def border_admixture_score(
     model and a fitted center-neighborhood mixture model. The reported score is
     the relative improvement of the mixture model over the center-only model.
 
-    Bootstrap confidence intervals are obtained by multinomial resampling of
+    If `n_boot` is set, bootstrap confidence intervals are obtained by multinomial resampling of
     the observed per-region gene count vectors within each focal cell.
 
     Notes
@@ -935,7 +935,7 @@ def border_admixture_score(
         Minimum number of genes required across the three regions combined.
     pseudocount : float, default=0.5
         Pseudocount used when converting counts to proportions.
-    n_boot : int, default=200
+    n_boot : int, default=0
         Number of bootstrap replicates per cell.
     ci_level : float, default=0.95
         Percentile confidence interval level.

--- a/src/segtraq/rs/utils.py
+++ b/src/segtraq/rs/utils.py
@@ -928,7 +928,7 @@ def _bootstrap_mixture_fit(
     x_center: np.ndarray,
     x_border: np.ndarray,
     x_neighborhood: np.ndarray,
-    n_boot: int = 200,
+    n_boot: int = 0,
     min_transcripts: int = 10,
     min_genes: int = 5,
     pseudocount: float = 0.5,
@@ -943,7 +943,7 @@ def _bootstrap_mixture_fit(
     ----------
     x_center, x_border, x_neighborhood : np.ndarray
         Gene count vectors for the center, border, and neighborhood regions.
-    n_boot : int, default=200
+    n_boot : int, default=0
         Number of bootstrap replicates.
     min_transcripts : int, default=10
         Minimum number of transcripts required in each region.
@@ -994,6 +994,11 @@ def _bootstrap_mixture_fit(
     p_center = x_center / n_center
     p_border = x_border / n_border
     p_neighborhood = x_neighborhood / n_neighborhood
+
+    if n_boot <= 0:
+        return {
+            "border_admixture_score": float(score) if np.isfinite(score) else np.nan,
+        }
 
     boot_scores = []
 


### PR DESCRIPTION
We still provide the option to do bootstrapping to computed confidence intervals for the `border_admixture_score`, but it is disabled by default.