### PR TITLE
Clustering stability/single cluster edge case

### DIFF
--- a/src/segtraq/cs/clustering_stability.py
+++ b/src/segtraq/cs/clustering_stability.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pandas as pd
 import spatialdata as sd
@@ -77,7 +79,7 @@ def cluster_connectedness(
     if isinstance(resolution, float):
         resolution = [resolution]
 
-    best_distance = 0.0
+    best_distance = np.nan
     if cell_type_key is not None:
         if cell_type_key not in adata.obs:
             raise ValueError(
@@ -127,8 +129,13 @@ def cluster_connectedness(
                 valid_labels,
                 use_weights=use_weights,
             )
-            if distance_val > best_distance:
+            if np.isnan(best_distance) or distance_val > best_distance:
                 best_distance = float(distance_val)
+        else:
+            warnings.warn(
+                f"Leiden clustering at resolution {res} produced only one cluster. Skipping connectedness calculation.",
+                stacklevel=2,
+            )
 
     if inplace:
         merge_into_uns(sdata, tables_key=tables_key, updates={"cluster_connectedness": best_distance})
@@ -194,7 +201,7 @@ def silhouette_score(
     adata = sdata.tables[tables_key]
     key = None
 
-    best_silhouette_score = -float("inf")
+    best_silhouette_score = np.nan
     if not isinstance(resolution, list | tuple):
         resolution = [resolution]
 
@@ -253,8 +260,14 @@ def silhouette_score(
 
                 silhouette_avg = _silhouette_score(pca, labels, metric=metric)
 
-                if silhouette_avg > best_silhouette_score:
+                if np.isnan(best_silhouette_score) or silhouette_avg > best_silhouette_score:
                     best_silhouette_score = float(silhouette_avg)
+            else:
+                warnings.warn(
+                    f"Leiden clustering at resolution {res} produced only one cluster. "
+                    f"Skipping silhouette score calculation.",
+                    stacklevel=2,
+                )
 
     if inplace and key is not None:
         merge_into_uns(sdata, tables_key=tables_key, updates={key: best_silhouette_score})
@@ -316,8 +329,16 @@ def purity(
         )
         cluster_keys.append(key_added)
 
-    purity_matrix = purity_pairwise(adata, cluster_keys)
-    mean_purity = float(purity_mean(purity_matrix))
+    n_clusters_per_key = [adata.obs[k].nunique() for k in cluster_keys]
+    if all(n <= 1 for n in n_clusters_per_key):
+        warnings.warn(
+            "All clustering results produced only one cluster. Please increase the clustering resolution.",
+            stacklevel=2,
+        )
+        mean_purity = float("nan")
+    else:
+        purity_matrix = purity_pairwise(adata, cluster_keys)
+        mean_purity = float(purity_mean(purity_matrix))
 
     if inplace:
         merge_into_uns(sdata, tables_key=tables_key, updates={"mean_purity": mean_purity})
@@ -379,8 +400,17 @@ def adjusted_rand_index(
             leiden_kwargs=leiden_kwargs,
         )
         cluster_keys.append(key_added)
-    pairwise_aris = ari_pairwise(adata, cluster_keys)
-    mean_ari = float(ari_mean(pairwise_aris))
+
+    n_clusters_per_key = [adata.obs[k].nunique() for k in cluster_keys]
+    if all(n <= 1 for n in n_clusters_per_key):
+        warnings.warn(
+            "All clustering results produced only one cluster. Please increase the clustering resolution.",
+            stacklevel=2,
+        )
+        mean_ari = float("nan")
+    else:
+        pairwise_aris = ari_pairwise(adata, cluster_keys)
+        mean_ari = float(ari_mean(pairwise_aris))
 
     if inplace:
         merge_into_uns(sdata, tables_key=tables_key, updates={"mean_ari": mean_ari})

--- a/src/segtraq/cs/clustering_stability.py
+++ b/src/segtraq/cs/clustering_stability.py
@@ -113,7 +113,8 @@ def cluster_connectedness(
             key_prefix=key_prefix,
             random_state=random_state,
             use_hvg=use_hvg,
-            recompute_neighbors=False,
+            recompute_neighbors=True,
+            filter_zero_count_cells=True,
             leiden_kwargs=leiden_kwargs,
         )
         labels = adata.obs[key_added].values
@@ -248,7 +249,8 @@ def silhouette_score(
                 key_prefix=key_prefix,
                 random_state=random_state,
                 use_hvg=use_hvg,
-                recompute_neighbors=False,
+                recompute_neighbors=True,
+                filter_zero_count_cells=True,
                 leiden_kwargs=leiden_kwargs,
             )
 

--- a/src/segtraq/cs/clustering_stability.py
+++ b/src/segtraq/cs/clustering_stability.py
@@ -76,7 +76,7 @@ def cluster_connectedness(
     """
     adata = sdata.tables[tables_key]
 
-    if isinstance(resolution, float):
+    if isinstance(resolution, float | int):
         resolution = [resolution]
 
     best_distance = np.nan

--- a/src/segtraq/cs/clustering_stability.py
+++ b/src/segtraq/cs/clustering_stability.py
@@ -9,6 +9,7 @@ from ..constants import CONNECTIVITIES_KEY, NEIGHBORS_KEY, PCA_KEY
 from ..utils import _get_pca_and_neighbors, merge_into_uns
 from .utils import (
     _cluster_connectedness,
+    _validate_resolution,
     ari_mean,
     ari_pairwise,
     purity_mean,
@@ -75,9 +76,8 @@ def cluster_connectedness(
         The best (highest) cluster connectedness across resolutions.
     """
     adata = sdata.tables[tables_key]
-
-    if isinstance(resolution, float | int):
-        resolution = [resolution]
+    # transforming the resolutions into a list if it is not already one
+    resolution = _validate_resolution(resolution)
 
     best_distance = np.nan
     if cell_type_key is not None:
@@ -202,8 +202,8 @@ def silhouette_score(
     key = None
 
     best_silhouette_score = np.nan
-    if not isinstance(resolution, list | tuple):
-        resolution = [resolution]
+    # transforming the resolutions into a list if it is not already one
+    resolution = _validate_resolution(resolution)
 
     if cell_type_key is not None:
         if cell_type_key not in adata.obs:

--- a/src/segtraq/cs/clustering_stability.py
+++ b/src/segtraq/cs/clustering_stability.py
@@ -113,7 +113,6 @@ def cluster_connectedness(
             key_prefix=key_prefix,
             random_state=random_state,
             use_hvg=use_hvg,
-            recompute_neighbors=True,
             filter_zero_count_cells=True,
             leiden_kwargs=leiden_kwargs,
         )
@@ -249,7 +248,6 @@ def silhouette_score(
                 key_prefix=key_prefix,
                 random_state=random_state,
                 use_hvg=use_hvg,
-                recompute_neighbors=True,
                 filter_zero_count_cells=True,
                 leiden_kwargs=leiden_kwargs,
             )

--- a/src/segtraq/cs/utils.py
+++ b/src/segtraq/cs/utils.py
@@ -15,12 +15,12 @@ def _validate_resolution(resolution: list[float] | tuple[float, ...] | float | i
     for res in resolution:
         if not isinstance(res, float | int):
             raise ValueError(f"Resolution {res} is not a float or int.")
-        if res <= 0:
+        if res < 0:
             raise ValueError(f"Resolution {res} must be positive.")
     return resolution
 
 
-def filter_zero_count_cells(adata: ad.AnnData) -> ad.AnnData:
+def _filter_zero_count_cells(adata: ad.AnnData) -> ad.AnnData:
     """
     Return a view of adata excluding cells with zero total counts.
     Does NOT modify the original object.
@@ -134,11 +134,16 @@ def run_leiden_clustering_on_random_subset(
     key_prefix: str = "leiden",
     random_state: int = 42,
     use_hvg: bool = False,
+    filter_zero_count_cells: bool = True,
     recompute_neighbors: bool = True,
     leiden_kwargs: dict | None = None,
 ):
     adata_full = sdata.tables[tables_key]
-    adata = filter_zero_count_cells(adata_full)
+    if filter_zero_count_cells:
+        assert recompute_neighbors, (
+            "Cannot filter zero-count cells without recomputing neighbors. Please set recompute_neighbors=True."
+        )
+        adata = _filter_zero_count_cells(adata_full)
 
     # --- Perform subsetting --- #
     adata_subset, subset_label = subset_adata(

--- a/src/segtraq/cs/utils.py
+++ b/src/segtraq/cs/utils.py
@@ -9,6 +9,17 @@ from sklearn.metrics import adjusted_rand_score, confusion_matrix
 from ..constants import CONNECTIVITIES_KEY, NEIGHBORS_KEY, PCA_KEY
 
 
+def _validate_resolution(resolution: list[float] | tuple[float, ...] | float | int) -> list[float]:
+    if isinstance(resolution, float | int):
+        resolution = [resolution]
+    for res in resolution:
+        if not isinstance(res, float | int):
+            raise ValueError(f"Resolution {res} is not a float or int.")
+        if res <= 0:
+            raise ValueError(f"Resolution {res} must be positive.")
+    return resolution
+
+
 def filter_zero_count_cells(adata: ad.AnnData) -> ad.AnnData:
     """
     Return a view of adata excluding cells with zero total counts.

--- a/src/segtraq/cs/utils.py
+++ b/src/segtraq/cs/utils.py
@@ -135,15 +135,18 @@ def run_leiden_clustering_on_random_subset(
     random_state: int = 42,
     use_hvg: bool = False,
     filter_zero_count_cells: bool = True,
-    recompute_neighbors: bool = True,
     leiden_kwargs: dict | None = None,
 ):
+    # neighbors are only recomputed when necessary,
+    # i.e. if there are zero-cound cells or no result is cached
+    recompute_neighbors = False
     adata_full = sdata.tables[tables_key]
-    if filter_zero_count_cells:
-        assert recompute_neighbors, (
-            "Cannot filter zero-count cells without recomputing neighbors. Please set recompute_neighbors=True."
-        )
+    num_zero_count_cells = (
+        (adata_full.X.sum(axis=1) == 0).sum() if sp.issparse(adata_full.X) else (adata_full.X.sum(axis=1) == 0).sum()
+    )
+    if num_zero_count_cells > 0 and filter_zero_count_cells:
         adata = _filter_zero_count_cells(adata_full)
+        recompute_neighbors = True
 
     # --- Perform subsetting --- #
     adata_subset, subset_label = subset_adata(

--- a/tests/cs/test_adjusted_rand_index.py
+++ b/tests/cs/test_adjusted_rand_index.py
@@ -25,3 +25,12 @@ def test_adjusted_rand_index_invalid_leiden_kwargs(sdata_new):
         st.cs.adjusted_rand_index(
             sdata_new, resolution=1.0, key_prefix="leiden_subset", leiden_kwargs={"invalid_key": "invalid_value"}
         )
+
+
+def test_adjusted_rand_index_single_cluster(sdata_new):
+    # Use a very low resolution to force a single cluster
+    ari = st.cs.adjusted_rand_index(sdata_new, resolution=0.0001, key_prefix="leiden_single_cluster")
+    assert isinstance(ari, float), "ARI should be a float"
+    # NaN check (NaN is defined to be unequal to everything, including itself)
+    assert ari != ari, "ARI should be NaN when only one cluster is produced"
+    assert "mean_ari" in sdata_new.tables["table"].uns.keys(), "'mean_ari' should be present in uns"

--- a/tests/cs/test_adjusted_rand_index.py
+++ b/tests/cs/test_adjusted_rand_index.py
@@ -30,6 +30,6 @@ def test_adjusted_rand_index_invalid_leiden_kwargs(sdata_new):
 
 def test_adjusted_rand_index_single_cluster(sdata_new):
     # Use a very low resolution to force a single cluster
-    ari = st.cs.adjusted_rand_index(sdata_new, resolution=0.0001, key_prefix="leiden_single_cluster")
+    ari = st.cs.adjusted_rand_index(sdata_new, resolution=0, key_prefix="leiden_single_cluster")
     assert np.isnan(ari), "ARI should be NaN when only one cluster is produced"
     assert "mean_ari" in sdata_new.tables["table"].uns.keys(), "'mean_ari' should be present in uns"

--- a/tests/cs/test_adjusted_rand_index.py
+++ b/tests/cs/test_adjusted_rand_index.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 import segtraq as st
@@ -30,7 +31,5 @@ def test_adjusted_rand_index_invalid_leiden_kwargs(sdata_new):
 def test_adjusted_rand_index_single_cluster(sdata_new):
     # Use a very low resolution to force a single cluster
     ari = st.cs.adjusted_rand_index(sdata_new, resolution=0.0001, key_prefix="leiden_single_cluster")
-    assert isinstance(ari, float), "ARI should be a float"
-    # NaN check (NaN is defined to be unequal to everything, including itself)
-    assert ari != ari, "ARI should be NaN when only one cluster is produced"
+    assert np.isnan(ari), "ARI should be NaN when only one cluster is produced"
     assert "mean_ari" in sdata_new.tables["table"].uns.keys(), "'mean_ari' should be present in uns"

--- a/tests/cs/test_cluster_connectedness.py
+++ b/tests/cs/test_cluster_connectedness.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import segtraq as st
 
@@ -10,6 +11,16 @@ def test_cluster_connectedness(sdata_new):
     assert "cluster_connectedness" in sdata_new.tables["table"].uns.keys(), (
         "'cluster_connectedness' should be present in uns"
     )
+
+
+def test_cluster_connectedness_invalid_resolution(sdata_new):
+    with pytest.raises(ValueError):
+        st.cs.cluster_connectedness(
+            sdata_new,
+            resolution=-0.5,
+            key_prefix="leiden_subset",
+            random_state=42,
+        )
 
 
 def test_cluster_connectedness_single_cluster(sdata_new):

--- a/tests/cs/test_cluster_connectedness.py
+++ b/tests/cs/test_cluster_connectedness.py
@@ -17,7 +17,7 @@ def test_cluster_connectedness_invalid_resolution(sdata_new):
     with pytest.raises(ValueError):
         st.cs.cluster_connectedness(
             sdata_new,
-            resolution=-0.5,
+            resolution=-1,
             key_prefix="leiden_subset",
             random_state=42,
         )
@@ -25,7 +25,7 @@ def test_cluster_connectedness_invalid_resolution(sdata_new):
 
 def test_cluster_connectedness_single_cluster(sdata_new):
     # Use a very low resolution to force a single cluster
-    cc = st.cs.cluster_connectedness(sdata_new, resolution=0.0001, key_prefix="leiden_single_cluster", random_state=42)
+    cc = st.cs.cluster_connectedness(sdata_new, resolution=0, key_prefix="leiden_single_cluster", random_state=42)
     assert np.isnan(cc), "Cluster connectedness should be NaN when only one cluster is produced"
     assert "cluster_connectedness" in sdata_new.tables["table"].uns.keys(), (
         "'cluster_connectedness' should be present in uns"

--- a/tests/cs/test_cluster_connectedness.py
+++ b/tests/cs/test_cluster_connectedness.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 import segtraq as st
 
 
@@ -13,9 +15,7 @@ def test_cluster_connectedness(sdata_new):
 def test_cluster_connectedness_single_cluster(sdata_new):
     # Use a very low resolution to force a single cluster
     cc = st.cs.cluster_connectedness(sdata_new, resolution=0.0001, key_prefix="leiden_single_cluster", random_state=42)
-    assert isinstance(cc, float), "Cluster connectedness should be a float"
-    # NaN check (NaN is defined to be unequal to everything, including itself)
-    assert cc != cc, "Cluster connectedness should be NaN when only one cluster is produced"
+    assert np.isnan(cc), "Cluster connectedness should be NaN when only one cluster is produced"
     assert "cluster_connectedness" in sdata_new.tables["table"].uns.keys(), (
         "'cluster_connectedness' should be present in uns"
     )

--- a/tests/cs/test_cluster_connectedness.py
+++ b/tests/cs/test_cluster_connectedness.py
@@ -8,3 +8,14 @@ def test_cluster_connectedness(sdata_new):
     assert "cluster_connectedness" in sdata_new.tables["table"].uns.keys(), (
         "'cluster_connectedness' should be present in uns"
     )
+
+
+def test_cluster_connectedness_single_cluster(sdata_new):
+    # Use a very low resolution to force a single cluster
+    cc = st.cs.cluster_connectedness(sdata_new, resolution=0.0001, key_prefix="leiden_single_cluster", random_state=42)
+    assert isinstance(cc, float), "Cluster connectedness should be a float"
+    # NaN check (NaN is defined to be unequal to everything, including itself)
+    assert cc != cc, "Cluster connectedness should be NaN when only one cluster is produced"
+    assert "cluster_connectedness" in sdata_new.tables["table"].uns.keys(), (
+        "'cluster_connectedness' should be present in uns"
+    )

--- a/tests/cs/test_purity.py
+++ b/tests/cs/test_purity.py
@@ -25,7 +25,7 @@ def test_purity_invalid_frac_cells_subset(sdata_new):
 
 def test_purity_single_cluster(sdata_new):
     # Use a very low resolution to force a single cluster
-    purity = st.cs.purity(sdata_new, resolution=0.0001, key_prefix="leiden_single_cluster")
+    purity = st.cs.purity(sdata_new, resolution=0, key_prefix="leiden_single_cluster")
     assert np.isnan(purity), "Purity should be NaN when only one cluster is produced"
     assert "mean_purity" in sdata_new.tables["table"].uns.keys(), (
         "Mean purity should be stored in sdata_new.tables['table'].uns"

--- a/tests/cs/test_purity.py
+++ b/tests/cs/test_purity.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 import segtraq as st
@@ -25,9 +26,7 @@ def test_purity_invalid_frac_cells_subset(sdata_new):
 def test_purity_single_cluster(sdata_new):
     # Use a very low resolution to force a single cluster
     purity = st.cs.purity(sdata_new, resolution=0.0001, key_prefix="leiden_single_cluster")
-    assert isinstance(purity, float), "Purity should be a float"
-    # NaN check (NaN is defined to be unequal to everything, including itself)
-    assert purity != purity, "Purity should be NaN when only one cluster is produced"
+    assert np.isnan(purity), "Purity should be NaN when only one cluster is produced"
     assert "mean_purity" in sdata_new.tables["table"].uns.keys(), (
         "Mean purity should be stored in sdata_new.tables['table'].uns"
     )

--- a/tests/cs/test_purity.py
+++ b/tests/cs/test_purity.py
@@ -20,3 +20,14 @@ def test_purity_invalid_frac_cells_subset(sdata_new):
             key_prefix="leiden_subset",
             frac_cells_subset=1.5,  # Invalid fraction > 1
         )
+
+
+def test_purity_single_cluster(sdata_new):
+    # Use a very low resolution to force a single cluster
+    purity = st.cs.purity(sdata_new, resolution=0.0001, key_prefix="leiden_single_cluster")
+    assert isinstance(purity, float), "Purity should be a float"
+    # NaN check (NaN is defined to be unequal to everything, including itself)
+    assert purity != purity, "Purity should be NaN when only one cluster is produced"
+    assert "mean_purity" in sdata_new.tables["table"].uns.keys(), (
+        "Mean purity should be stored in sdata_new.tables['table'].uns"
+    )

--- a/tests/cs/test_silhouette_score.py
+++ b/tests/cs/test_silhouette_score.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import segtraq as st
 
@@ -10,6 +11,16 @@ def test_silhouette_score(sdata_new):
     assert "silhouette_score" in sdata_new.tables["table"].uns.keys(), (
         "Silhouette score should be stored in sdata_new.uns"
     )
+
+
+def test_silhouette_score_invalid_resolution(sdata_new):
+    with pytest.raises(ValueError):
+        st.cs.silhouette_score(
+            sdata_new,
+            resolution=-0.5,
+            key_prefix="leiden_subset",
+            random_state=42,  # Invalid negative resolution
+        )
 
 
 def test_silhouette_score_single_cluster(sdata_new):

--- a/tests/cs/test_silhouette_score.py
+++ b/tests/cs/test_silhouette_score.py
@@ -8,3 +8,16 @@ def test_silhouette_score(sdata_new):
     assert "silhouette_score" in sdata_new.tables["table"].uns.keys(), (
         "Silhouette score should be stored in sdata_new.uns"
     )
+
+
+def test_silhouette_score_single_cluster(sdata_new):
+    # Use a very low resolution to force a single cluster
+    silhouette_score = st.cs.silhouette_score(
+        sdata_new, resolution=0.0001, key_prefix="leiden_single_cluster", random_state=42
+    )
+    assert isinstance(silhouette_score, float), "Silhouette score should be a float"
+    # NaN check (NaN is defined to be unequal to everything, including itself)
+    assert silhouette_score != silhouette_score, "Silhouette score should be NaN when only one cluster is produced"
+    assert "silhouette_score" in sdata_new.tables["table"].uns.keys(), (
+        "Silhouette score should be stored in sdata_new.uns"
+    )

--- a/tests/cs/test_silhouette_score.py
+++ b/tests/cs/test_silhouette_score.py
@@ -17,7 +17,7 @@ def test_silhouette_score_invalid_resolution(sdata_new):
     with pytest.raises(ValueError):
         st.cs.silhouette_score(
             sdata_new,
-            resolution=-0.5,
+            resolution=-1,
             key_prefix="leiden_subset",
             random_state=42,  # Invalid negative resolution
         )
@@ -26,7 +26,7 @@ def test_silhouette_score_invalid_resolution(sdata_new):
 def test_silhouette_score_single_cluster(sdata_new):
     # Use a very low resolution to force a single cluster
     silhouette_score = st.cs.silhouette_score(
-        sdata_new, resolution=0.0001, key_prefix="leiden_single_cluster", random_state=42
+        sdata_new, resolution=0, key_prefix="leiden_single_cluster", random_state=42
     )
     assert np.isnan(silhouette_score), "Silhouette score should be NaN when only one cluster is produced"
     assert "silhouette_score" in sdata_new.tables["table"].uns.keys(), (

--- a/tests/cs/test_silhouette_score.py
+++ b/tests/cs/test_silhouette_score.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 import segtraq as st
 
 
@@ -15,9 +17,7 @@ def test_silhouette_score_single_cluster(sdata_new):
     silhouette_score = st.cs.silhouette_score(
         sdata_new, resolution=0.0001, key_prefix="leiden_single_cluster", random_state=42
     )
-    assert isinstance(silhouette_score, float), "Silhouette score should be a float"
-    # NaN check (NaN is defined to be unequal to everything, including itself)
-    assert silhouette_score != silhouette_score, "Silhouette score should be NaN when only one cluster is produced"
+    assert np.isnan(silhouette_score), "Silhouette score should be NaN when only one cluster is produced"
     assert "silhouette_score" in sdata_new.tables["table"].uns.keys(), (
         "Silhouette score should be stored in sdata_new.uns"
     )


### PR DESCRIPTION
In the case where Leiden clustering only creates one cluster, clustering stability metrics are now `NaN`.
Also fixes a bug caused by the filtering of zero-count cells which would lead to some disconnected cells at resolution 0.