### PR TITLE
Stpuppeteer/sensitivity

### DIFF
--- a/docs/notebooks/10x_xenium_focus.py
+++ b/docs/notebooks/10x_xenium_focus.py
@@ -1384,10 +1384,10 @@ for method, st in st_dict.items():
     )
 
 # %% [markdown]
-# Across all methods, positive and negative markers co-occur less frequently than expected
-# under independence, indicating a consistent depletion of co-expression.
-# Although the differences are minor, Proseg shows the strongest depletion of co-expression
-# of positive and negative markers.
+# Across all methods, marker pairs with significant mutual exclusivity show substantially
+# lower co-expression than expected under independence.
+# Although the differences are minor, ProSeg shows the strongest depletion of co-expression
+# among these marker pairs.
 
 # %%
 rows = []
@@ -1396,24 +1396,45 @@ for method, st in st_dict.items():
     tbl = st.sdata.tables["table"]
     mecr_df = tbl.uns["mutually_exclusive_coexpression_rate"]
 
-    # Filter significant, finite odds ratios and p-values
-    df_sig = mecr_df[
+    # Keep marker pairs with significant mutual exclusivity
+    df_sig = mecr_df.loc[
         mecr_df["odds_ratio"].notna()
         & np.isfinite(mecr_df["odds_ratio"])
         & mecr_df["pvalue"].notna()
         & np.isfinite(mecr_df["pvalue"])
+        & (mecr_df["odds_ratio"] < 1)
         & (mecr_df["pvalue"] < 0.05)
-    ]
+    ].copy()
 
-    # Build rows
-    rows.extend({"method": str(method), "Fisher_OR": np.log2(row["odds_ratio"])} for _, row in df_sig.iterrows())
+    rows.extend(
+        {
+            "method": str(method),
+            "Fisher_OR": row["odds_ratio"],
+        }
+        for _, row in df_sig.iterrows()
+    )
 
 df = pd.DataFrame(rows)
 
-median_order = df.groupby("method")["Fisher_OR"].median().sort_values().index.tolist()
-medians = df.groupby("method")["Fisher_OR"].median().reindex(median_order)
+# Order methods by mean OR
+mean_order = (
+    df.groupby("method")["Fisher_OR"]
+    .mean()
+    .sort_values()
+    .index
+    .tolist()
+)
 
-xtick_labels = [f"{m}\nmedian:({medians[m]:.2f})" for m in median_order]
+means = (
+    df.groupby("method")["Fisher_OR"]
+    .mean()
+    .reindex(mean_order)
+)
+
+xtick_labels = [
+    f"{m}\nmean: {means[m]:.2f}"
+    for m in mean_order
+]
 
 plt.figure(figsize=(6, 4))
 
@@ -1421,7 +1442,7 @@ ax = sns.violinplot(
     data=df,
     x="method",
     y="Fisher_OR",
-    order=median_order,
+    order=mean_order,
     palette="Set2",
     linewidth=2,
 )
@@ -1430,7 +1451,7 @@ sns.stripplot(
     data=df,
     x="method",
     y="Fisher_OR",
-    order=median_order,
+    order=mean_order,
     color="black",
     size=2.5,
     alpha=0.35,
@@ -1438,14 +1459,22 @@ sns.stripplot(
     ax=ax,
 )
 
-# Reference line: OR = 1
-ax.axhline(0, ls="--", lw=1, color="gray", alpha=0.6)
+# OR = 1 corresponds to independence
+ax.axhline(
+    1,
+    ls="--",
+    lw=1,
+    color="gray",
+    alpha=0.6,
+)
 
 ax.set_xticklabels(xtick_labels)
 
-ax.set_ylabel("log2 Fisher odds ratio")
+ax.set_ylabel("Mutually exclusive marker co-expression (odds ratio)")
 ax.set_xlabel("")
-ax.set_title("Significant associations among candidate mutually exclusive marker pairs")
+ax.set_title(
+    "Significantly mutually exclusive marker pairs"
+)
 
 plt.grid(axis="y", alpha=0.3)
 plt.tight_layout()

--- a/docs/notebooks/supervised.py
+++ b/docs/notebooks/supervised.py
@@ -692,8 +692,7 @@ plt.show()
 # Candidate pairs are constructed as unique, unordered combinations of positive and negative
 # markers across cell types, excluding gene pairs that co-occur as positive markers in any cell type.
 # Fisher’s exact test with `alternative="less"` is used to test whether genes co-occur less often
-# than expected under independence, while odds ratios are reported with a pseudocount correction
-# to avoid infinities in sparse data. By conditioning on the marginal detection frequencies of each gene,
+# than expected under independence. By conditioning on the marginal detection frequencies of each gene,
 # Fisher’s exact test does not favor methods with low overall transcript counts.
 
 # %%
@@ -709,46 +708,63 @@ rows = []
 tbl = st.sdata.tables["table"]
 mecr_df = tbl.uns["mutually_exclusive_coexpression_rate"]
 
-# Filter significant, finite odds ratios and p-values
-df_sig = mecr_df[
+# Keep marker pairs with significant mutual exclusivity
+df_sig = mecr_df.loc[
     mecr_df["odds_ratio"].notna()
     & np.isfinite(mecr_df["odds_ratio"])
     & mecr_df["pvalue"].notna()
     & np.isfinite(mecr_df["pvalue"])
+    & (mecr_df["odds_ratio"] < 1)
     & (mecr_df["pvalue"] < 0.05)
-]
+].copy()
 
-# Build rows
-rows.extend({"method": "Xenium", "Fisher_OR": np.log2(row["odds_ratio"])} for _, row in df_sig.iterrows())
+# Build plotting dataframe
+rows.extend(
+    {
+        "method": "Xenium",
+        "coexpression_odds_ratio": row["odds_ratio"],
+    }
+    for _, row in df_sig.iterrows()
+)
 
 df = pd.DataFrame(rows)
 
-median_order = df.groupby("method")["Fisher_OR"].median().sort_values().index.tolist()
+# Order by mean odds ratio
+mean_order = (
+    df.groupby("method")["coexpression_odds_ratio"]
+    .mean()
+    .sort_values()
+    .index
+    .tolist()
+)
 
-# Compute medians in plotting order
-medians = df.groupby("method")["Fisher_OR"].median().reindex(median_order)
+means = (
+    df.groupby("method")["coexpression_odds_ratio"]
+    .mean()
+    .reindex(mean_order)
+)
 
-# Build x-axis labels with medians
-xtick_labels = [f"{m}\nmedian:({medians[m]:.2f})" for m in median_order]
+xtick_labels = [
+    f"{m}\nmean: {means[m]:.2f}"
+    for m in mean_order
+]
 
 plt.figure(figsize=(3, 4))
 
-# --- Violin plot ---
 ax = sns.violinplot(
     data=df,
     x="method",
-    y="Fisher_OR",
-    order=median_order,
+    y="coexpression_odds_ratio",
+    order=mean_order,
     palette="Set2",
     linewidth=2,
 )
 
-# --- Stripplot overlay ---
 sns.stripplot(
     data=df,
     x="method",
-    y="Fisher_OR",
-    order=median_order,
+    y="coexpression_odds_ratio",
+    order=mean_order,
     color="black",
     size=2.5,
     alpha=0.35,
@@ -756,15 +772,20 @@ sns.stripplot(
     ax=ax,
 )
 
-# Reference line: OR = 1
-ax.axhline(0, ls="--", lw=1, color="gray", alpha=0.6)
+# OR = 1 corresponds to independence
+ax.axhline(
+    1,
+    ls="--",
+    lw=1,
+    color="gray",
+    alpha=0.6,
+)
 
-# Apply new x-axis labels
 ax.set_xticklabels(xtick_labels)
 
-ax.set_ylabel("log2 Fisher odds ratio")
+ax.set_ylabel("Marker co-expression odds ratio")
 ax.set_xlabel("")
-ax.set_title("Significant associations among candidate mutually exclusive marker pairs")
+ax.set_title("Significantly mutually exclusive marker pairs")
 
 plt.grid(axis="y", alpha=0.3)
 plt.tight_layout()

--- a/src/segtraq/SegTraQ.py
+++ b/src/segtraq/SegTraQ.py
@@ -147,7 +147,7 @@ class SegTraQ:
         filter_kwargs : dict or None, optional
             If `filter_low_quality_transcripts` is True, these keyword arguments are forwarded
             to the filtering function.
-            Possible keys are: `min_qv`, `control_genes`, `control_prefixes`, `inplace`.
+            Possible keys are: `min_qv`, `control_prefixes`, `inplace`.
             Please refer to the function `_filter_control_and_low_quality_transcripts` for details.
 
         Notes
@@ -1505,13 +1505,11 @@ class _SPFacade:
     def mutually_exclusive_coexpression_rate(
         self,
         markers: dict[str, dict[str, list[str]]],
-        pseudocount: float = 0.5,
         inplace: bool = True,
     ):
         return sp.mutually_exclusive_coexpression_rate(
             sdata=self._p.sdata,
             markers=markers,
-            pseudocount=pseudocount,
             tables_key=self._p.tables_key,
             tables_gene_key=self._p.tables_gene_key,
             tables_raw_counts_layer=self._p.tables_raw_counts_layer,

--- a/src/segtraq/cs/utils.py
+++ b/src/segtraq/cs/utils.py
@@ -191,6 +191,7 @@ def ari_pairwise(adata: ad.AnnData, cluster_keys: list[str]) -> np.ndarray:
 
             # Restrict to cells with non-missing labels in both clusterings
             mask = labels_i.notna() & labels_j.notna()
+
             labels_i_valid = labels_i[mask]
             labels_j_valid = labels_j[mask]
 

--- a/src/segtraq/rs/region_similarity.py
+++ b/src/segtraq/rs/region_similarity.py
@@ -340,56 +340,7 @@ def similarity_nucleus_cell(
         if hasattr(row, "toarray"):
             row = row.toarray()
         return np.asarray(row).ravel()
-
-    # test
-    problems = []
-
-    for _, row in match_df.iterrows():
-        cid = row[shapes_cell_id_key]
-        nid = row["nucleus_id"]
-
-        if pd.isna(nid):
-            continue
-
-        x_cell = _cell_count_vector(cid)
-        x_overlap = counts_intersection.loc[cid].to_numpy()
-
-        if x_overlap.sum() > x_cell.sum():
-            problems.append(
-                {
-                    "cell_id": cid,
-                    "cell_total": x_cell.sum(),
-                    "overlap_total": x_overlap.sum(),
-                    "difference": x_overlap.sum() - x_cell.sum(),
-                }
-            )
-
-    problems = pd.DataFrame(problems)
-
-    problems_gene = []
-
-    for _, row in match_df.iterrows():
-        cid = row[shapes_cell_id_key]
-        nid = row["nucleus_id"]
-
-        if pd.isna(nid):
-            continue
-
-        x_cell = _cell_count_vector(cid)
-        x_overlap = counts_intersection.loc[cid].to_numpy()
-
-        bad = x_overlap > x_cell
-
-        if bad.any():
-            problems_gene.append(
-                {
-                    "cell_id": cid,
-                    "n_genes": bad.sum(),
-                    "excess_transcripts": (x_overlap[bad] - x_cell[bad]).sum(),
-                }
-            )
-
-    problems_gene = pd.DataFrame(problems_gene)
+        
 
     def _compute_one(row: pd.Series, seed: np.uint32) -> dict:
         cid, nid = row[shapes_cell_id_key], row["nucleus_id"]

--- a/src/segtraq/rs/utils.py
+++ b/src/segtraq/rs/utils.py
@@ -573,69 +573,6 @@ def _get_center_border_counts(
     return expr_center, expr_border
 
 
-def _cosine_sim(x: np.ndarray, y: np.ndarray) -> float:
-    """Compute cosine similarity between two numeric vectors."""
-    x_norm = np.linalg.norm(x)
-    y_norm = np.linalg.norm(y)
-    if x_norm == 0.0 or y_norm == 0.0:
-        return np.nan
-    return float(np.dot(x, y) / (x_norm * y_norm))
-
-
-def _pf_log1p_pf(
-    x: np.ndarray,
-    scale: float = 1e4,
-) -> np.ndarray:
-    """Apply PFlog1pPF (shifted CLR) to one count vector.
-
-    Counts are first converted to proportions and scaled, followed by `log1p`.
-    The transformed profile is then centered by subtracting its mean across
-    genes. A zero-depth profile is returned as zeros.
-    """
-    if scale <= 0:
-        raise ValueError("`scale` must be > 0.")
-
-    x = np.asarray(x, dtype=float)
-
-    if x.ndim != 1:
-        raise ValueError("`x` must be a one-dimensional array.")
-
-    total = x.sum()
-    if total <= 0:
-        return np.zeros_like(x, dtype=float)
-
-    transformed = np.log1p(scale * x / total)
-    transformed -= transformed.mean()
-
-    return transformed
-
-
-def _cosine_similarity_two_vectors(
-    x_a: np.ndarray,
-    x_b: np.ndarray,
-    scale: float,
-) -> float:
-    """Compute cosine similarity between PFlog1pPF-transformed count profiles."""
-    x_a = np.rint(np.asarray(x_a)).astype(int)
-    x_b = np.rint(np.asarray(x_b)).astype(int)
-
-    # Genes that are zero in both profiles contribute identical centered values
-    # after PFlog1pPF. Keep them in the cosine analytically while avoiding work on
-    # thousands of zero entries for sparse expression profiles.
-    mask = (x_a + x_b) > 0
-    if not mask.any():
-        return np.nan
-
-    sim = _cosine_similarity_rows(
-        x_a[mask][None, :],
-        x_b[mask][None, :],
-        scale=scale,
-        n_features_total=len(x_a),
-    )[0]
-
-    return float(sim) if np.isfinite(sim) else np.nan
-
-
 def _cosine_similarity_rows(
     x_a: np.ndarray,
     x_b: np.ndarray,

--- a/src/segtraq/sp/supervised.py
+++ b/src/segtraq/sp/supervised.py
@@ -16,46 +16,47 @@ def mutually_exclusive_coexpression_rate(
     tables_key: str = "table",
     tables_gene_key: str | None = None,
     tables_raw_counts_layer: str | None = None,
-    pseudocount: float = 0.5,
     inplace: bool = True,
 ) -> pd.DataFrame:
     """
-    Compute mutual exclusivity between marker genes using Fisher's exact test.
-    Returns a DataFrame with one row per unordered gene pair.
+    Assess co-expression of marker genes expected to be mutually exclusive.
+
+    Candidate gene pairs are defined from positive and negative marker sets.
+    For each pair, a one-sided Fisher's exact test evaluates whether the genes
+    are detected together less frequently than expected under independence.
 
     Parameters
     ----------
     sdata : SpatialData-like
-        Must contain `tables[tables_key]` as an AnnData with expression and `.obs` metadata.
+        Must contain `tables[tables_key]` as an AnnData with expression data.
     markers : dict
-        A dictionary mapping cell types to their positive and negative markers, in the format
+        Mapping of cell types to positive and negative markers:
         {cell_type: {"positive": list[str], "negative": list[str]}}.
     tables_key : str, optional, default="table"
         Key of the AnnData table in `sdata.tables`.
     tables_gene_key : str or None, default=None
         Column in `sdata.tables[tables_key].var` containing gene identifiers.
-        If `None`, `sdata.tables[tables_key].var_names` are used.
-    tables_raw_counts_layer : str | None, optional
-        Layer containing count data. If `None`, `adata.X` is used if it looks
-        like counts.
-        If a layer is specified, it must exist and contain count-like values.
-    pseudocount : float, optional, default=0.5
-        Pseudocount added to all cells of the contingency table to avoid
-        division by zero when computing odds ratios.
-        This is equivalent to the Haldane-Anscombe correction, see https://pmc.ncbi.nlm.nih.gov/articles/PMC7398076.
+        If None, `var_names` are used.
+    tables_raw_counts_layer : str or None, optional
+        Layer containing raw counts. If None, `adata.X` is used.
     inplace : bool, optional, default=True
-        If True, store the resulting DataFrame in `sdata.tables[tables_key].uns["MECR"]`.
+        If True, store the resulting DataFrame in
+        `sdata.tables[tables_key].uns["mutually_exclusive_coexpression_rate"]`.
 
     Returns
     -------
     pd.DataFrame
-        Columns: ``gene1``, ``gene2``, ``odds_ratio``, ``pvalue``, ``a``, ``b``, ``c``, ``d``,
-        where (a, b, c, d) are the counts in the contingency table.
+        One row per candidate marker-gene pair with columns:
+        `gene1`, `gene2`, `odds_ratio`, `pvalue`, `a`, `b`, `c`, and `d`.
+
+        Odds ratios below 1 indicate less co-expression than expected under
+        independence. The one-sided Fisher p-value quantifies evidence for
+        such mutual exclusivity.
     """
     adata = sdata.tables[tables_key]
 
     X = _get_count_matrix(adata, layer=tables_raw_counts_layer)
-    X_dense = X.toarray() if hasattr(X, "toarray") else X
+    X_dense = X.toarray() if hasattr(X, "toarray") else np.asarray(X)
 
     var_index = _get_genes(
         adata=adata,
@@ -63,7 +64,6 @@ def mutually_exclusive_coexpression_rate(
     )
 
     n_cells = X_dense.shape[0]
-    pseudocount = float(pseudocount)
 
     # --- build unique unordered candidate pairs ---
     candidate_pairs = set()
@@ -112,20 +112,21 @@ def mutually_exclusive_coexpression_rate(
             "Please report this to the developers of SegTraQ."
         )
 
-        # Fisher's exact returns exact p-value for under-co-occurrence (mutual exclusivity)
+        # Fisher's exact test for under-co-occurrence (mutual exclusivity)
         try:
-            _, pval = fisher_exact([[a, b], [c, d]], alternative="less")
+            odds_ratio, pval = fisher_exact(
+                [[a, b], [c, d]],
+                alternative="less",
+            )
         except Exception:
+            odds_ratio = np.nan
             pval = np.nan
-
-        # odds ratio is computed with a pseudocount (Haldane–Anscombe correction)
-        or_pseudocount = ((a + pseudocount) * (d + pseudocount)) / ((b + pseudocount) * (c + pseudocount))
 
         rows.append(
             {
                 "gene1": g1,
                 "gene2": g2,
-                "odds_ratio": float(or_pseudocount),
+                "odds_ratio": float(odds_ratio) if np.isfinite(odds_ratio) else odds_ratio,
                 "pvalue": float(pval) if np.isfinite(pval) else np.nan,
                 "a": a,
                 "b": b,
@@ -228,7 +229,7 @@ def neighbor_contamination(
             stacklevel=2,
         )
         adata.obsm["spatial"] = adata.obs[[tables_centroid_x_key, tables_centroid_y_key]].to_numpy()
-        sq.gr.spatial_neighbors(adata, delaunay=True, coord_type="generic")
+        sq.gr.spatial_neighbors_delaunay(adata)
 
     # extract neighbor indices
     G = adata.obsp[neighbors_key]
@@ -506,7 +507,7 @@ def marker_purity(
             stacklevel=2,
         )
         adata.obsm["spatial"] = adata.obs[[tables_centroid_x_key, tables_centroid_y_key]].to_numpy()
-        sq.gr.spatial_neighbors(adata, delaunay=True, coord_type="generic")
+        sq.gr.spatial_neighbors_delaunay(adata)
 
     G = adata.obsp[neighbors_key]
     if sparse.issparse(G):

--- a/src/segtraq/utils.py
+++ b/src/segtraq/utils.py
@@ -340,6 +340,16 @@ def _get_norm_log(
     sc.pp.normalize_total(tmp, target_sum=target_sum)
     sc.pp.log1p(tmp)
 
+    # PF / CLR centering:
+    # subtract each cell's mean log-expression across genes
+    # cell_mean = np.asarray(tmp.X.mean(axis=1)).ravel()
+
+    # if sparse.issparse(tmp.X):
+    #     tmp.X = tmp.X.toarray()
+
+    # cell_mean = np.asarray(tmp.X.mean(axis=1)).ravel()
+    # tmp.X -= cell_mean[:, None]
+
     adata.layers[NORM_LOG_LAYER] = tmp.X
     return adata
 


### PR DESCRIPTION
## Summary

This PR refines the MECR metric and includes several smaller compatibility and cleanup changes.

* Updated `mutually_exclusive_coexpression_rate`:

  * removed the pseudocount/Haldane–Anscombe correction, because in case of perfect mutual exclusivity OR should be zero regardless of cell count
  * updated docs

* Updated MECR visualization in the example notebooks:

* Updated Squidpy Delaunay graph construction to avoid warnings and use the new `spatial_neighbors_delaunay()` API in `marker_purity` and `neighbor_contamination`.

* Removed temporary/debugging code from the region-similarity implementation and removed unused PFlog1pPF/cosine helper functions.
